### PR TITLE
robosuite_env: remove extra condition in get_observation

### DIFF
--- a/robomimic/envs/env_robosuite.py
+++ b/robomimic/envs/env_robosuite.py
@@ -195,8 +195,7 @@ class EnvRobosuite(EB.EnvBase):
                 # ensures that we don't accidentally add robot wrist images a second time
                 pf = robot.robot_model.naming_prefix
                 for k in di:
-                    if k.startswith(pf) and (k not in ret) and \
-                            (not k.endswith("proprio-state")) and (k in ObsUtils.OBS_KEYS_TO_MODALITIES):
+                    if k.startswith(pf) and (k not in ret) and (not k.endswith("proprio-state")):
                         ret[k] = np.array(di[k])
         else:
             # minimal proprioception for older versions of robosuite


### PR DESCRIPTION
It seems the recent observation modality PR is leading our `dataset_states_to_obs.py` script to break — it’s not recording the robot proprio observations in the dataset anymore. I traced the issue to [this line](https://github.com/ARISE-Initiative/robomimic/blob/c666dc0ebbbaf9076d2e4a5e2dd97ee0806876f1/robomimic/envs/env_robosuite.py#L199). Specifically in the observation modality PR we added an extra condition `k in ObsUtils.OBS_KEYS_TO_MODALITIES` which is causing things to break.

This extra condition can safely be reverted, as it only affects converting states to obs for robosuite envs and we don't need this condition in this case.