### PR TITLE
Remove self reference for goals in vae prior

### DIFF
--- a/robomimic/models/vae_nets.py
+++ b/robomimic/models/vae_nets.py
@@ -140,7 +140,7 @@ class Prior(Module):
             obs_group_shapes["obs"] = OrderedDict(obs_shapes)
             if goal_shapes is not None and len(goal_shapes) > 0:
                 assert isinstance(goal_shapes, OrderedDict)
-                obs_group_shapes["goal"] = OrderedDict(self.goal_shapes)
+                obs_group_shapes["goal"] = OrderedDict(goal_shapes)
             self.prior_module = MIMO_MLP(
                 input_obs_group_shapes=obs_group_shapes,
                 output_shapes=mlp_output_shapes,


### PR DESCRIPTION
[this line](https://github.com/ARISE-Initiative/robomimic/blob/39b985e7e6e8d2c380b0c86d9b47dbb390e07446/robomimic/models/vae_nets.py#L143) was causing a bug because `self.goals` is not initialized. We don't actually need the `self.` in the first place