### PR TITLE
Expand path for output directory

### DIFF
--- a/robomimic/utils/train_utils.py
+++ b/robomimic/utils/train_utils.py
@@ -48,7 +48,7 @@ def get_exp_dir(config, auto_remove_exp_dir=False):
     time_str = datetime.datetime.fromtimestamp(t_now).strftime('%Y%m%d%H%M%S')
 
     # create directory for where to dump model parameters, tensorboard logs, and videos
-    base_output_dir = config.train.output_dir
+    base_output_dir = os.path.expanduser(config.train.output_dir)
     if not os.path.isabs(base_output_dir):
         # relative paths are specified relative to robomimic module location
         base_output_dir = os.path.join(robomimic.__path__[0], base_output_dir)


### PR DESCRIPTION
If the output directory in the configs is set to `~/path/to/output` robomimic doesn't recognize the `~/` refers to the home directory and instead creates the output directory relative to the robomimic directory. This PR fixes this issue.