### PR TITLE
V0.3 pretrained rep fix

### DIFF
--- a/robomimic/models/base_nets.py
+++ b/robomimic/models/base_nets.py
@@ -96,6 +96,7 @@ class Sequential(torch.nn.Sequential, Module):
                 assert isinstance(arg, nn.Module)
         torch.nn.Sequential.__init__(self, *args)
         self.fixed = False
+        self.has_output_shape = has_output_shape
 
     def output_shape(self, input_shape=None):
         """
@@ -109,6 +110,8 @@ class Sequential(torch.nn.Sequential, Module):
         Returns:
             out_shape ([int]): list of integers corresponding to output shape
         """
+        if not self.has_output_shape:
+            raise NotImplementedError("Output shape is not defined for this module")
         out_shape = input_shape
         for module in self:
             out_shape = module.output_shape(out_shape)

--- a/robomimic/models/base_nets.py
+++ b/robomimic/models/base_nets.py
@@ -89,6 +89,11 @@ class Sequential(torch.nn.Sequential, Module):
     Compose multiple Modules together (defined above).
     """
     def __init__(self, *args, has_output_shape = True):
+        """
+        Args:
+            has_output_shape (bool, optional): indicates whether output_shape can be called on the Sequential module.
+                torch.nn modules do not have an output_shape, but Modules (defined above) do. Defaults to True.
+        """
         for arg in args:
             if has_output_shape:
                 assert isinstance(arg, Module)

--- a/robomimic/models/base_nets.py
+++ b/robomimic/models/base_nets.py
@@ -88,9 +88,12 @@ class Sequential(torch.nn.Sequential, Module):
     """
     Compose multiple Modules together (defined above).
     """
-    def __init__(self, *args):
+    def __init__(self, *args, has_output_shape = True):
         for arg in args:
-            assert isinstance(arg, Module)
+            if has_output_shape:
+                assert isinstance(arg, Module)
+            else:
+                assert isinstance(arg, nn.Module)
         torch.nn.Sequential.__init__(self, *args)
         self.fixed = False
 
@@ -574,7 +577,7 @@ class R3MConv(ConvBase):
             transforms.CenterCrop(224),
             transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
         )
-        self.nets = nn.Sequential(*([preprocess] + list(net.module.convnet.children())))
+        self.nets = Sequential(*([preprocess] + list(net.module.convnet.children())), has_output_shape = False)
         if freeze:
             self.nets.freeze()
 


### PR DESCRIPTION
Allows Sequential class to be created with torch.nn modules that don't have output shapes defined