### PR TITLE
fix mujoco py import

### DIFF
--- a/robomimic/envs/env_robosuite.py
+++ b/robomimic/envs/env_robosuite.py
@@ -7,11 +7,17 @@ import json
 import numpy as np
 from copy import deepcopy
 
-import mujoco_py
 import robosuite
 
 import robomimic.utils.obs_utils as ObsUtils
 import robomimic.envs.env_base as EB
+
+# protect against missing mujoco-py module, since robosuite might be using mujoco-py or DM backend
+try:
+    import mujoco_py
+    MUJOCO_EXCEPTIONS = [mujoco_py.builder.MujocoException]
+except ImportError:
+    MUJOCO_EXCEPTIONS = []
 
 
 class EnvRobosuite(EB.EnvBase):
@@ -375,7 +381,7 @@ class EnvRobosuite(EB.EnvBase):
         that the entire training run doesn't crash because of a bad policy that causes unstable
         simulation computations.
         """
-        return (mujoco_py.builder.MujocoException)
+        return tuple(MUJOCO_EXCEPTIONS)
 
     def __repr__(self):
         """


### PR DESCRIPTION
- Previously we had a mujoco_py import in `env_robosuite.py` to prevent rollout exceptions from crashing the training run. Now, make this import optional. Fixes #66 