### PR TITLE
image proc/unproc: do not modify image in-place

### DIFF
--- a/robomimic/utils/obs_utils.py
+++ b/robomimic/utils/obs_utils.py
@@ -379,7 +379,7 @@ def process_frame(frame, channel_dim, scale):
     # Channel size should either be 3 (RGB) or 1 (depth)
     assert (frame.shape[-1] == channel_dim)
     frame = TU.to_float(frame)
-    frame /= scale
+    frame = frame / scale
     frame = frame.clip(0.0, 1.0)
     frame = batch_image_hwc_to_chw(frame)
 
@@ -441,7 +441,7 @@ def unprocess_frame(frame, channel_dim, scale):
     """
     assert frame.shape[-3] == channel_dim # check for channel dimension
     frame = batch_image_chw_to_hwc(frame)
-    frame *= scale
+    frame = frame * scale
     return frame
 
 


### PR DESCRIPTION
`frame *= scale` modified the image in-place. Use `frame = frame * scale` instead. Similarly for division. Should fix this issue: https://github.com/ARISE-Initiative/robomimic/issues/41