### PR TITLE
Added DDIM scheduler to Diffusion Policy Implementation

### DIFF
--- a/robomimic/algo/diffusion_policy.py
+++ b/robomimic/algo/diffusion_policy.py
@@ -87,6 +87,15 @@ class DiffusionPolicyUNet(PolicyAlgo):
                 clip_sample=self.algo_config.ddpm.clip_sample,
                 prediction_type=self.algo_config.ddpm.prediction_type
             )
+        elif self.algo_config.ddim.enabled:
+            noise_scheduler = DDIMScheduler(
+                num_train_timesteps=self.algo_config.ddim.num_train_timesteps,
+                beta_schedule=self.algo_config.ddim.beta_schedule,
+                clip_sample=self.algo_config.ddim.clip_sample,
+                set_alpha_to_one=self.algo_config.ddim.set_alpha_to_one,
+                steps_offset=self.algo_config.ddim.steps_offset,
+                prediction_type=self.algo_config.ddim.prediction_type
+            )
         else:
             raise RuntimeError()
         

--- a/robomimic/algo/diffusion_policy.py
+++ b/robomimic/algo/diffusion_policy.py
@@ -312,7 +312,12 @@ class DiffusionPolicyUNet(PolicyAlgo):
         Ta = self.algo_config.horizon.action_horizon
         Tp = self.algo_config.horizon.prediction_horizon
         action_dim = self.ac_dim
-        num_inference_timesteps = self.algo_config.ddpm.num_inference_timesteps
+        if self.algo_config.ddpm.enabled is True:
+            num_inference_timesteps = self.algo_config.ddpm.num_inference_timesteps
+        elif self.algo_config.ddim.enabled is True:
+            num_inference_timesteps = self.algo_config.ddim.num_inference_timesteps
+        else:
+            raise ValueError
         
         # select network
         nets = self.nets

--- a/robomimic/config/diffusion_policy_config.py
+++ b/robomimic/config/diffusion_policy_config.py
@@ -45,4 +45,13 @@ class DiffusionPolicyConfig(BaseConfig):
         self.algo.ddpm.beta_schedule = 'squaredcos_cap_v2'
         self.algo.ddpm.clip_sample = True
         self.algo.ddpm.prediction_type = 'epsilon'
-                
+
+        ## DDIM
+        self.algo.ddim.enabled = False
+        self.algo.ddim.num_train_timesteps = 100
+        self.algo.ddim.num_inference_timesteps = 10
+        self.algo.ddim.beta_schedule = 'squaredcos_cap_v2'
+        self.algo.ddim.clip_sample = True
+        self.algo.ddim.set_alpha_to_one = True
+        self.algo.ddim.steps_offset = 0
+        self.algo.ddim.prediction_type = 'epsilon'

--- a/robomimic/exps/templates/diffusion_policy.json
+++ b/robomimic/exps/templates/diffusion_policy.json
@@ -93,6 +93,16 @@
             "beta_schedule": "squaredcos_cap_v2",
             "clip_sample": true,
             "prediction_type": "epsilon"
+        },
+        "ddim": {
+            "enabled": false,
+            "num_train_timesteps": 100,
+            "num_inference_timesteps": 10,
+            "beta_schedule": "squaredcos_cap_v2",
+            "clip_sample": true,
+            "set_alpha_to_one": true,
+            "steps_offset": 0,
+            "prediction_type": "epsilon"
         }
     },
     "observation": {

--- a/robomimic/scripts/config_gen/diffusion_gen.py
+++ b/robomimic/scripts/config_gen/diffusion_gen.py
@@ -27,6 +27,27 @@ def make_generator_helper(args):
         values=[1000],
     )
 
+    # use ddim by default
+    generator.add_param(
+        key="algo.ddim.enabled",
+        name="ddim",
+        group=1001,
+        values=[
+            True,
+            # False,
+        ],
+    )
+    generator.add_param(
+        key="algo.ddpm.enabled",
+        name="ddpm",
+        group=1001,
+        values=[
+            False,
+            # True,
+        ],
+        hidename=True,
+    )
+
     if args.env == "r2d2":
         generator.add_param(
             key="train.data",
@@ -97,34 +118,6 @@ def make_generator_helper(args):
             ],
             value_names=[
                 "abs",
-            ],
-        )
-
-        generator.add_param(
-            key="algo.ddpm.enabled",
-            name="ddpm",
-            group=-1,
-            values=[
-                [
-                    False,
-                ],
-            ],
-            value_names=[
-                "off",
-            ],
-        )
-
-        generator.add_param(
-            key="algo.ddim.enabled",
-            name="ddim",
-            group=-1,
-            values=[
-                [
-                    True,
-                ],
-            ],
-            value_names=[
-                "on",
             ],
         )
 

--- a/robomimic/scripts/config_gen/diffusion_gen.py
+++ b/robomimic/scripts/config_gen/diffusion_gen.py
@@ -99,6 +99,36 @@ def make_generator_helper(args):
                 "abs",
             ],
         )
+
+        generator.add_param(
+            key="algo.ddpm.enabled",
+            name="ddpm",
+            group=-1,
+            values=[
+                [
+                    False,
+                ],
+            ],
+            value_names=[
+                "off",
+            ],
+        )
+
+        generator.add_param(
+            key="algo.ddim.enabled",
+            name="ddim",
+            group=-1,
+            values=[
+                [
+                    True,
+                ],
+            ],
+            value_names=[
+                "on",
+            ],
+        )
+
+
     else:
         raise ValueError
     


### PR DESCRIPTION
Added DDIM scheduler as an option for Diffusion Policy. Currently, if you run
```
python robomimic/scripts/config_gen/diffusion_gen.py --env=square
```
it will set:
```
if argsenv == "square":
...
    algo.ddpm.enabled = False
    algo.ddim.enabled = True
```
I'm not sure what's the best way to allow users flexibly specify which scheduler to use.
@snasiriany @amandlek 