### PR TITLE
fix obs norm

### DIFF
--- a/robomimic/algo/algo.py
+++ b/robomimic/algo/algo.py
@@ -494,14 +494,16 @@ class RolloutPolicy(object):
             ob (dict): single observation dictionary from environment (no batch dimension, 
                 and np.array values for each key)
         """
-        if self.obs_normalization_stats is not None:
-            # limit normalization to obs keys being used, in case environment includes extra keys
-            ob = { k : ob[k] for k in self.policy.global_config.all_obs_keys }
-            ob = ObsUtils.normalize_obs(ob, obs_normalization_stats=self.obs_normalization_stats)
         ob = TensorUtils.to_tensor(ob)
         ob = TensorUtils.to_batch(ob)
         ob = TensorUtils.to_device(ob, self.policy.device)
         ob = TensorUtils.to_float(ob)
+        if self.obs_normalization_stats is not None:
+            # ensure obs_normalization_stats are torch Tensors on proper device
+            obs_normalization_stats = TensorUtils.to_float(TensorUtils.to_device(TensorUtils.to_tensor(self.obs_normalization_stats), self.policy.device))
+            # limit normalization to obs keys being used, in case environment includes extra keys
+            ob = { k : ob[k] for k in self.policy.global_config.all_obs_keys }
+            ob = ObsUtils.normalize_obs(ob, obs_normalization_stats=obs_normalization_stats)
         return ob
 
     def __repr__(self):

--- a/robomimic/algo/algo.py
+++ b/robomimic/algo/algo.py
@@ -221,6 +221,9 @@ class Algo(object):
             batch (dict): postproceesed batch
         """
 
+        # ensure obs_normalization_stats are torch Tensors on proper device
+        obs_normalization_stats = TensorUtils.to_float(TensorUtils.to_device(TensorUtils.to_tensor(obs_normalization_stats), self.device))
+
         # we will search the nested batch dictionary for the following special batch dict keys
         # and apply the processing function to their values (which correspond to observations)
         obs_keys = ["obs", "next_obs", "goal_obs"]
@@ -492,6 +495,8 @@ class RolloutPolicy(object):
                 and np.array values for each key)
         """
         if self.obs_normalization_stats is not None:
+            # limit normalization to obs keys being used, in case environment includes extra keys
+            ob = { k : ob[k] for k in self.policy.global_config.all_obs_keys }
             ob = ObsUtils.normalize_obs(ob, obs_normalization_stats=self.obs_normalization_stats)
         ob = TensorUtils.to_tensor(ob)
         ob = TensorUtils.to_batch(ob)

--- a/robomimic/utils/dataset.py
+++ b/robomimic/utils/dataset.py
@@ -442,8 +442,6 @@ class SequenceDataset(torch.utils.data.Dataset):
             seq_length=self.seq_length,
             prefix="obs"
         )
-        if self.hdf5_normalize_obs:
-            meta["obs"] = ObsUtils.normalize_obs(meta["obs"], obs_normalization_stats=self.obs_normalization_stats)
 
         if self.load_next_obs:
             meta["next_obs"] = self.get_obs_sequence_from_demo(
@@ -454,8 +452,6 @@ class SequenceDataset(torch.utils.data.Dataset):
                 seq_length=self.seq_length,
                 prefix="next_obs"
             )
-            if self.hdf5_normalize_obs:
-                meta["next_obs"] = ObsUtils.normalize_obs(meta["next_obs"], obs_normalization_stats=self.obs_normalization_stats)
 
         if goal_index is not None:
             goal = self.get_obs_sequence_from_demo(
@@ -466,8 +462,6 @@ class SequenceDataset(torch.utils.data.Dataset):
                 seq_length=1,
                 prefix="next_obs",
             )
-            if self.hdf5_normalize_obs:
-                goal = ObsUtils.normalize_obs(goal, obs_normalization_stats=self.obs_normalization_stats)
             meta["goal_obs"] = {k: goal[k][0] for k in goal}  # remove sequence dimension for goal
 
         return meta

--- a/robomimic/utils/dataset.py
+++ b/robomimic/utils/dataset.py
@@ -348,8 +348,8 @@ class SequenceDataset(torch.utils.data.Dataset):
         obs_normalization_stats = { k : {} for k in merged_stats }
         for k in merged_stats:
             # note we add a small tolerance of 1e-3 for std
-            obs_normalization_stats[k]["mean"] = merged_stats[k]["mean"]
-            obs_normalization_stats[k]["std"] = np.sqrt(merged_stats[k]["sqdiff"] / merged_stats[k]["n"]) + 1e-3
+            obs_normalization_stats[k]["mean"] = merged_stats[k]["mean"].astype(np.float32)
+            obs_normalization_stats[k]["std"] = (np.sqrt(merged_stats[k]["sqdiff"] / merged_stats[k]["n"]) + 1e-3).astype(np.float32)
         return obs_normalization_stats
 
     def get_obs_normalization_stats(self):

--- a/robomimic/utils/obs_utils.py
+++ b/robomimic/utils/obs_utils.py
@@ -488,7 +488,8 @@ def normalize_obs(obs_dict, obs_normalization_stats):
         # check shape consistency
         shape_len_diff = len(mean.shape) - len(obs_dict[m].shape)
         assert shape_len_diff in [0, 1], "shape length mismatch in @normalize_obs"
-        assert mean.shape[shape_len_diff:] == obs_dict[m].shape, "shape mismatch in @normalize obs"
+        # if dict has no leading batch dim, check shapes match exactly, else allow first dim to broadcast
+        assert mean.shape[1:] == obs_dict[m].shape[(1 - shape_len_diff):], "shape mismatch in @normalize_obs"
 
         # handle case where obs dict is not batched by removing stats batch dimension
         if shape_len_diff == 1:


### PR DESCRIPTION
Fixes:
- we were normalizing observations twice
- fix assert statement in ObsUtils.normalize_obs function to properly account for leading batch dimensions
- we were not sending the obs normalization stats to GPU
- fix an issue where obs normalization would throw an error during rollouts if the environment includes extra obs keys
- move obs norm during rollout to be on gpu for consistency