### PR TITLE
possibly fix obs norm for batches with seq length > 1

### DIFF
--- a/robomimic/algo/algo.py
+++ b/robomimic/algo/algo.py
@@ -238,15 +238,7 @@ class Algo(object):
                     if d[k] is not None:
                         d[k] = ObsUtils.process_obs_dict(d[k])
                         if obs_normalization_stats is not None:
-                            m = list(d[k].keys())[0]
-                            shape_diff = len(d[k][m].shape) - len(obs_normalization_stats[m].shape)
-                            assert shape_diff in [1, 2]
-                            if shape_diff == 2:
-                                # leading dimensions are batch and time ([B, T, ...])
-                                d[k] = TensorUtils.time_distributed(d[k], ObsUtils.normalize_obs, obs_normalization_stats=obs_normalization_stats)
-                            else:
-                                # leading dimensions are batch ([B, ...])
-                                d[k] = ObsUtils.normalize_obs(d[k], obs_normalization_stats=obs_normalization_stats)
+                            d[k] = ObsUtils.normalize_obs(d[k], obs_normalization_stats=obs_normalization_stats)
                 elif isinstance(d[k], dict):
                     # search down into dictionary
                     recurse_helper(d[k])

--- a/robomimic/algo/algo.py
+++ b/robomimic/algo/algo.py
@@ -238,7 +238,15 @@ class Algo(object):
                     if d[k] is not None:
                         d[k] = ObsUtils.process_obs_dict(d[k])
                         if obs_normalization_stats is not None:
-                            d[k] = ObsUtils.normalize_obs(d[k], obs_normalization_stats=obs_normalization_stats)
+                            m = list(d[k].keys())[0]
+                            shape_diff = len(d[k][m].shape) - len(obs_normalization_stats[m].shape)
+                            assert shape_diff in [1, 2]
+                            if shape_diff == 2:
+                                # leading dimensions are batch and time ([B, T, ...])
+                                d[k] = TensorUtils.time_distributed(d[k], ObsUtils.normalize_obs, obs_normalization_stats=obs_normalization_stats)
+                            else:
+                                # leading dimensions are batch ([B, ...])
+                                d[k] = ObsUtils.normalize_obs(d[k], obs_normalization_stats=obs_normalization_stats)
                 elif isinstance(d[k], dict):
                     # search down into dictionary
                     recurse_helper(d[k])

--- a/robomimic/utils/obs_utils.py
+++ b/robomimic/utils/obs_utils.py
@@ -492,7 +492,10 @@ def normalize_obs(obs_dict, obs_normalization_stats):
         assert shape_len_diff >= 0, "shape length mismatch in @normalize_obs"
         assert obs_dict[m].shape[-m_num_dims:] == mean.shape, "shape mismatch in @normalize_obs"
 
-        # obs can have one or more leading batch dims - prepare for broadcasting
+        # Obs can have one or more leading batch dims - prepare for broadcasting.
+        # 
+        # As an example, if the obs has shape [B, T, D] and our mean / std stats are shape [D]
+        # then we should pad the stats to shape [1, 1, D].
         reshape_padding = tuple([1] * shape_len_diff)
         mean = mean.reshape(reshape_padding + tuple(mean.shape))
         std = std.reshape(reshape_padding + tuple(std.shape))


### PR DESCRIPTION
- observation normalization is broken for batches with leading shapes [B, T] - this should fix it, and also handle batches with leading shapes [B] as before