### PR TITLE
R2D2 share encoder for varied cameras

### DIFF
--- a/robomimic/config/base_config.py
+++ b/robomimic/config/base_config.py
@@ -291,6 +291,7 @@ class BaseConfig(Config):
         self.observation.encoder.low_dim.obs_randomizer_kwargs.do_not_lock_keys()
 
         # =============== RGB default encoder (ResNet backbone + linear layer output) ===============
+        self.observation.encoder.rgb.fuser = None                               # How to combine the outputs of multi-camera vision encoders
         self.observation.encoder.rgb.core_class = "VisualCore"                  # Default VisualCore class combines backbone (like ResNet-18) with pooling operation (like spatial softmax)
         self.observation.encoder.rgb.core_kwargs = Config()                     # See models/obs_core.py for important kwargs to set and defaults used
         self.observation.encoder.rgb.core_kwargs.do_not_lock_keys()

--- a/robomimic/models/obs_core.py
+++ b/robomimic/models/obs_core.py
@@ -232,6 +232,7 @@ class DeFiNeVisualCore(EncoderCore, BaseNets.ConvBase):
         self.backbone = eval(backbone_class)(**backbone_kwargs)
 
         feat_shape = self.backbone.output_shape(input_shape)
+        self.feat_shape = feat_shape
         # net_list = [self.backbone]
         self.nets["backbone"] = self.backbone
 
@@ -254,8 +255,6 @@ class DeFiNeVisualCore(EncoderCore, BaseNets.ConvBase):
         else:
             self.pool = None
 
-        post_proc_list.append(torch.nn.Conv1d(in_channels = feat_shape[-1], out_channels=feature_dimension*2, kernel_size=1))
-        post_proc_list.append(torch.nn.Conv1d(in_channels = feature_dimension*2, out_channels=feature_dimension, kernel_size=1))
 
         # flatten layer
         if self.flatten:
@@ -312,7 +311,6 @@ class DeFiNeVisualCore(EncoderCore, BaseNets.ConvBase):
 
         x = self.nets["backbone"].forward(image=image, intrinsics=intrinsics, extrinsics=extrinsics)
         # x = self.nets["backbone"].forward(inputs["image"])
-        x = x.permute(0, 2, 1) # B, L, C --> B, C, L
         x = self.nets["post_proc"](x)
 
         return x

--- a/robomimic/models/obs_nets.py
+++ b/robomimic/models/obs_nets.py
@@ -103,13 +103,24 @@ def obs_encoder_factory(
 
         input_maps = enc_kwargs.get("input_maps", {})
 
+        if any("camera/image/varied_camera" in s for s in enc.obs_shapes.keys()) and ("camera/image/varied_camera" in k):
+            existing_varied_cam = [a for a in enc.obs_shapes.keys() if "camera/image/varied_camera" in a][0]
+            share = existing_varied_cam
+            net_class = None
+            net_kwargs = None
+        else: 
+            share = None
+            net_class = enc_kwargs["core_class"]
+            net_kwargs = enc_kwargs["core_kwargs"]
+
         enc.register_obs_key(
             name=k,
             shape=obs_shape,
             input_map=input_maps.get(k, None),
-            net_class=enc_kwargs["core_class"],
-            net_kwargs=enc_kwargs["core_kwargs"],
+            net_class=net_class,
+            net_kwargs=net_kwargs,
             randomizers=randomizers,
+            share_net_from=share,
         )
 
     enc.make()

--- a/robomimic/models/obs_nets.py
+++ b/robomimic/models/obs_nets.py
@@ -245,11 +245,11 @@ class ObservationEncoder(Module):
             input_features = self.obs_nets["camera/image/hand_camera_left_image"].feat_shape
             # First scales down number of features on each pixel
             self.c1 = torch.nn.Conv1d(in_channels = input_features[1], out_channels=512, kernel_size=1)
-            self.c2 = torch.nn.Conv1d(in_channels = 512, out_channels=64, kernel_size=1)
-            layer = nn.TransformerEncoderLayer(d_model=64, nhead=8, batch_first = True, dim_feedforward = 64)
+            self.c2 = torch.nn.Conv1d(in_channels = 512, out_channels=512, kernel_size=1)
+            layer = nn.TransformerEncoderLayer(d_model=512, nhead=8, batch_first = True)
             self.fusernetwork = nn.TransformerEncoder(layer, num_layers=6)
             # Finally flatten and linear layer before concatenated with other low dim features
-            self.l1 = torch.nn.Linear(input_features[0] * self.num_images * 64, 2048)
+            self.l1 = torch.nn.Linear(input_features[0] * self.num_images * 512, 2048)
 
     def final_collation(self, feats):
         if self.fuser is None:

--- a/robomimic/scripts/config_gen/diffusion_gen.py
+++ b/robomimic/scripts/config_gen/diffusion_gen.py
@@ -27,6 +27,13 @@ def make_generator_helper(args):
         values=[1000],
     )
 
+    generator.add_param(
+        key="train.batch_size",
+        name="",
+        group=-1,
+        values=[8],
+    )
+
     # use ddim by default
     generator.add_param(
         key="algo.ddim.enabled",
@@ -55,10 +62,10 @@ def make_generator_helper(args):
             name="ds",
             group=2,
             values=[
-                [{"path": p} for p in scan_datasets("~/Downloads/example_pen_in_cup", postfix="trajectory_im128.h5")],
+                ["DATAPATH"]
             ],
             value_names=[
-                "pen-in-cup",
+                "data",
             ],
         )
         generator.add_param(
@@ -98,13 +105,35 @@ def make_generator_helper(args):
                 # "3cams-stereo",
             ]
         )
+        generator.add_param(
+            key="observation.encoder.rgb.obs_randomizer_class",
+            name="obsrand",
+            group=130,
+            values=[
+                # "CropRandomizer", # crop only
+                # "ColorRandomizer", # jitter only
+                ["ColorRandomizer", "CropRandomizer"], # jitter, followed by crop
+            ],
+            hidename=True,
+        )
+        generator.add_param(
+            key="observation.encoder.rgb.obs_randomizer_kwargs",
+            name="obsrandargs",
+            group=-1,
+            values=[
+                # {"crop_height": 116, "crop_width": 116, "num_crops": 1, "pos_enc": False}, # crop only
+                # {}, # jitter only
+                [{}, {"crop_height": 116, "crop_width": 116, "num_crops": 1, "pos_enc": False}], # jitter, followed by crop
+            ],
+            hidename=True,
+        )
 
         generator.add_param(
             key="observation.modalities.obs.low_dim",
             name="ldkeys",
             group=2498,
             values=[
-                ["robot_state/cartesian_position", "robot_state/gripper_position"],
+                # ["robot_state/cartesian_position", "robot_state/gripper_position"],
                 [
                     "robot_state/cartesian_position", "robot_state/gripper_position",
                     "camera/extrinsics/hand_camera_left", "camera/intrinsics/hand_camera_left", # "camera/extrinsics/hand_camera_left_gripper_offset", 
@@ -116,27 +145,28 @@ def make_generator_helper(args):
                 ]
             ],
             value_names=[
-                "proprio",
+                # "proprio",
                 "proprio-cam",
             ],
             hidename=False,
         )
+        ## All of the following are needed for DeFiNe style encoding
         generator.add_param(
             key="observation.encoder.rgb.input_maps",
             name="",
             group=2498,
             values=[
-                {
-                    "camera/image/hand_camera_left_image": {
-                        "image": "camera/image/hand_camera_left_image",
-                    },
-                    "camera/image/varied_camera_1_left_image": {
-                        "image": "camera/image/varied_camera_1_left_image",
-                    },
-                    "camera/image/varied_camera_2_left_image": {
-                        "image": "camera/image/varied_camera_2_left_image",
-                    },
-                },
+                # {
+                #     "camera/image/hand_camera_left_image": {
+                #         "image": "camera/image/hand_camera_left_image",
+                #     },
+                #     "camera/image/varied_camera_1_left_image": {
+                #         "image": "camera/image/varied_camera_1_left_image",
+                #     },
+                #     "camera/image/varied_camera_2_left_image": {
+                #         "image": "camera/image/varied_camera_2_left_image",
+                #     },
+                # },
                 {
                     "camera/image/hand_camera_left_image": {
                         "image": "camera/image/hand_camera_left_image",
@@ -156,7 +186,7 @@ def make_generator_helper(args):
                 },
             ],
             value_names=[
-                "define-image-only",
+                # "define-image-only",
                 "define",
             ],
             hidename=True,
@@ -166,13 +196,21 @@ def make_generator_helper(args):
             name="",
             group=2498,
             values=[
-                False,
+                # False,
                 True,
             ],
             hidename=True,
         )
-
-
+        generator.add_param(
+            key="observation.encoder.rgb.core_kwargs.backbone_kwargs.pretrained",
+            name="",
+            group=2498,
+            values=[
+                # False,
+                True,
+            ],
+            hidename=True,
+        )
         generator.add_param(
             key="observation.encoder.rgb.core_class",
             name="visenc",
@@ -191,7 +229,25 @@ def make_generator_helper(args):
             name="visdim",
             group=1234,
             values=[
-                64, #512
+                None
+            ],
+            hidename=True,
+        )
+        generator.add_param(
+            key="observation.encoder.rgb.core_kwargs.flatten",
+            name="flatten",
+            group=1234,
+            values=[
+                False
+            ],
+            hidename=True,
+        )
+        generator.add_param(
+            key="observation.encoder.rgb.fuser",
+            name="fuser",
+            group=1234,
+            values=[
+                "transformer"
             ],
             hidename=True,
         )
@@ -202,8 +258,8 @@ def make_generator_helper(args):
         #     name="backbone",
         #     group=1234,
         #     values=[
-        #         "ResNet18Conv",
-        #         # "ResNet50Conv",
+        #         # "ResNet18Conv",
+        #         "ResNet50Conv",
         #     ],
         # )
         # generator.add_param(
@@ -211,8 +267,8 @@ def make_generator_helper(args):
         #     name="visdim",
         #     group=1234,
         #     values=[
-        #         64,
-        #         # 512,
+        #         # 64,
+        #         512,
         #     ],
         # )
 

--- a/robomimic/utils/camera_utils.py
+++ b/robomimic/utils/camera_utils.py
@@ -1957,7 +1957,7 @@ class ResNetEncoder(nn.Module, ABC):
         super().__init__()
 
         self.num_ch_enc = np.array([64, 64, 128, 256, 512])
-        self.features = []
+        # features = []
 
         assert version in RESNET_VERSIONS, f'Invalid ResNet version: {version}'
 
@@ -1974,18 +1974,20 @@ class ResNetEncoder(nn.Module, ABC):
     def forward(self, input_image):
         """Network forward pass"""
 
+        features = []
+
         x = (input_image - 0.45) / 0.225
         x = self.encoder.conv1(x)
         x = self.encoder.bn1(x)
 
-        self.features.clear()
-        self.features.append(self.encoder.relu(x))
-        self.features.append(self.encoder.layer1(self.encoder.maxpool(self.features[-1])))
-        self.features.append(self.encoder.layer2(self.features[-1]))
-        self.features.append(self.encoder.layer3(self.features[-1]))
-        self.features.append(self.encoder.layer4(self.features[-1]))
+        features.clear()
+        features.append(self.encoder.relu(x))
+        features.append(self.encoder.layer1(self.encoder.maxpool(features[-1])))
+        features.append(self.encoder.layer2(features[-1]))
+        features.append(self.encoder.layer3(features[-1]))
+        features.append(self.encoder.layer4(features[-1]))
 
-        return self.features
+        return features
 
 
 class DeFiNeImageCamEncoder(nn.Module, ABC):

--- a/robomimic/utils/camera_utils.py
+++ b/robomimic/utils/camera_utils.py
@@ -2029,6 +2029,17 @@ class DeFiNeImageCamEncoder(nn.Module, ABC):
             }
         )
 
+        # Adding in another Conv2 layer that is applied [H/4, W/4, features] to
+        # reduce size
+        self.num_cam_channels = 186
+        self.num_image_channels = 3840 # ResNet50
+        if self.use_cam:
+            num_channels = self.num_image_channels + self.num_cam_channels
+        else:
+            num_channels = self.num_image_channels
+        self.finalconv = torch.nn.Conv2d(num_channels, 1024, 2, stride=2)
+
+
     def get_rgb_feat(self, rgb, rgb_feat_type="resnet_all"):
         """Exract image features"""
         if rgb_feat_type == 'convnet':
@@ -2097,8 +2108,13 @@ class DeFiNeImageCamEncoder(nn.Module, ABC):
                 rgb = datum['feat']
                 rgb_flat = rgb.view(*rgb.shape[:-2], -1).permute(0, 2, 1)
                 encoding['rgb'] = rgb_flat
-
-            encoding['all'] = torch.cat([val for val in encoding.values()], -1)
+            # Adding in another Conv2 layer that is applied [H/4, W/4, features] to
+            # reduce size
+            stacked = torch.cat([val for val in encoding.values()], -1)
+            st_sh = stacked.shape
+            stacked = stacked.reshape(st_sh[0], int(np.sqrt(st_sh[1])), int(np.sqrt(st_sh[1])), st_sh[-1])
+            stacked = self.finalconv(stacked.permute(0, 3, 1, 2))
+            encoding['all'] = stacked.reshape(stacked.shape[0], stacked.shape[1], -1).permute(0, 2, 1)
             encodings.append(encoding)
 
         return encodings
@@ -2129,11 +2145,8 @@ class DeFiNeImageCamEncoder(nn.Module, ABC):
         return result
     
     def output_shape(self, input_shape):
-        num_cam_channels = 186
-        num_image_channels = 3840 # ResNet18: 512 + 256 + 128 + 64
-        num_sptial_feats = int(input_shape[1] / 4 * input_shape[2] / 4)
-        if self.use_cam:
-            num_channels = num_image_channels + num_cam_channels
-        else:
-            num_channels = num_image_channels
-        return (num_sptial_feats, num_channels)
+        # num_cam_channels = 186
+        # num_image_channels = 3840 # ResNet18: 512 + 256 + 128 + 64
+        num_sptial_feats = int(np.floor((input_shape[1] / 8))) * int(np.floor(input_shape[1] / 8))
+        # Updated to have the shapes outputted by the final conv2.
+        return (num_sptial_feats, 1024)


### PR DESCRIPTION
Sharing the encoder for the varied cameras in R2D2. @snasiriany I'm doing so simply by using the share_net parameter. If theres something else that needs to be added let me know. 