### PR TITLE
support for robosuite depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 
 -------
 ## Latest Updates
+- [10/11/2023] **v0.3.1**: support for extracting, training on, and visualizing depth observations for robosuite datasets
 - [07/03/2023] **v0.3.0**: BC-Transformer and IQL :brain:, support for DeepMind MuJoCo bindings :robot:, pre-trained image reps :eye:, wandb logging :chart_with_upwards_trend:, and more
 - [05/23/2022] **v0.2.1**: Updated website and documentation to feature more tutorials :notebook_with_decorative_cover:
 - [12/16/2021] **v0.2.0**: Modular observation modalities and encoders :wrench:, support for [MOMART](https://sites.google.com/view/il-for-mm/home) datasets :open_file_folder: [[release notes]](https://github.com/ARISE-Initiative/robomimic/releases/tag/v0.2.0) [[documentation]](https://robomimic.github.io/docs/v0.2/introduction/overview.html)

--- a/docs/api/robomimic.rst
+++ b/docs/api/robomimic.rst
@@ -24,6 +24,14 @@ robomimic.macros module
    :undoc-members:
    :show-inheritance:
 
+robomimic.macros\_private module
+--------------------------------
+
+.. automodule:: robomimic.macros_private
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 Module contents
 ---------------
 

--- a/docs/datasets/robosuite.md
+++ b/docs/datasets/robosuite.md
@@ -64,6 +64,9 @@ $ python dataset_states_to_obs.py --dataset /path/to/demo.hdf5 --output_name low
 # For including image observations
 $ python dataset_states_to_obs.py --dataset /path/to/demo.hdf5 --output_name image.hdf5 --done_mode 2 --camera_names agentview robot0_eye_in_hand --camera_height 84 --camera_width 84
 
+# For including depth observations too
+python dataset_states_to_obs.py --dataset /path/to/demo.hdf5 --output_name depth.hdf5 --done_mode 2 --camera_names agentview robot0_eye_in_hand --camera_height 84 --camera_width 84 --depth
+
 # Using dense rewards
 $ python dataset_states_to_obs.py --dataset /path/to/demo.hdf5 --output_name image_dense.hdf5 --done_mode 2 --dense --camera_names agentview robot0_eye_in_hand --camera_height 84 --camera_width 84
 

--- a/docs/tutorials/dataset_contents.md
+++ b/docs/tutorials/dataset_contents.md
@@ -49,6 +49,9 @@ $ python playback_dataset.py --dataset ../../tests/assets/test_v141.hdf5 --rende
 # Directly visualize the image observations in the dataset. This is especially useful for real robot datasets where there is no simulator to use for rendering.
 $ python playback_dataset.py --dataset ../../tests/assets/test_v141.hdf5 --use-obs --render_image_names agentview_image --video_path /tmp/obs_trajectory.mp4
 
+# Visualize depth observations as well.
+$ python playback_dataset.py --dataset /path/to/dataset.hdf5 --use-obs --render_image_names agentview_image --render_depth_names agentview_depth --video_path /tmp/obs_trajectory.mp4
+
 # Play the dataset actions in the environment to verify that the recorded actions are reasonable.
 $ python playback_dataset.py --dataset ../../tests/assets/test_v141.hdf5 --use-actions --render_image_names agentview --video_path /tmp/playback_dataset_with_actions.mp4
 

--- a/robomimic/__init__.py
+++ b/robomimic/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 
 # stores released dataset links and rollout horizons in global dictionary.

--- a/robomimic/envs/env_base.py
+++ b/robomimic/envs/env_base.py
@@ -25,6 +25,7 @@ class EnvBase(abc.ABC):
         render=False, 
         render_offscreen=False, 
         use_image_obs=False, 
+        use_depth_obs=False, 
         postprocess_visual_obs=True, 
         **kwargs,
     ):
@@ -40,6 +41,10 @@ class EnvBase(abc.ABC):
 
             use_image_obs (bool): if True, environment is expected to render rgb image observations
                 on every env.step call. Set this to False for efficiency reasons, if image
+                observations are not required.
+
+            use_depth_obs (bool): if True, environment is expected to render depth image observations
+                on every env.step call. Set this to False for efficiency reasons, if depth
                 observations are not required.
 
             postprocess_visual_obs (bool): if True, postprocess image observations
@@ -183,7 +188,18 @@ class EnvBase(abc.ABC):
 
     @classmethod
     @abc.abstractmethod
-    def create_for_data_processing(cls, camera_names, camera_height, camera_width, reward_shaping, **kwargs):
+    def create_for_data_processing(
+        cls, 
+        camera_names, 
+        camera_height, 
+        camera_width, 
+        reward_shaping, 
+        render=None, 
+        render_offscreen=None, 
+        use_image_obs=None, 
+        use_depth_obs=None, 
+        **kwargs,
+    ):
         """
         Create environment for processing datasets, which includes extracting
         observations, labeling dense / sparse rewards, and annotating dones in
@@ -194,6 +210,10 @@ class EnvBase(abc.ABC):
             camera_height (int): camera height for all cameras
             camera_width (int): camera width for all cameras
             reward_shaping (bool): if True, use shaped environment rewards, else use sparse task completion rewards
+            render (bool or None): optionally override rendering behavior
+            render_offscreen (bool or None): optionally override rendering behavior
+            use_image_obs (bool or None): optionally override rendering behavior
+            use_depth_obs (bool or None): optionally override rendering behavior
 
         Returns:
             env (EnvBase instance)

--- a/robomimic/envs/env_base.py
+++ b/robomimic/envs/env_base.py
@@ -210,10 +210,12 @@ class EnvBase(abc.ABC):
             camera_height (int): camera height for all cameras
             camera_width (int): camera width for all cameras
             reward_shaping (bool): if True, use shaped environment rewards, else use sparse task completion rewards
-            render (bool or None): optionally override rendering behavior
-            render_offscreen (bool or None): optionally override rendering behavior
-            use_image_obs (bool or None): optionally override rendering behavior
-            use_depth_obs (bool or None): optionally override rendering behavior
+            render (bool or None): optionally override rendering behavior. Defaults to False.
+            render_offscreen (bool or None): optionally override rendering behavior. The default value is True if
+                @camera_names is non-empty, False otherwise.
+            use_image_obs (bool or None): optionally override rendering behavior. The default value is True if
+                @camera_names is non-empty, False otherwise.
+            use_depth_obs (bool): if True, use depth observations
 
         Returns:
             env (EnvBase instance)

--- a/robomimic/envs/env_base.py
+++ b/robomimic/envs/env_base.py
@@ -229,4 +229,11 @@ class EnvBase(abc.ABC):
         simulation computations.
         """
         return
-    
+
+    @property
+    @abc.abstractmethod
+    def base_env(self):
+        """
+        Grabs base simulation environment.
+        """
+        return

--- a/robomimic/envs/env_gym.py
+++ b/robomimic/envs/env_gym.py
@@ -253,6 +253,13 @@ class EnvGym(EB.EnvBase):
         """
         return ()
 
+    @property
+    def base_env(self):
+        """
+        Grabs base simulation environment.
+        """
+        return self.env
+
     def __repr__(self):
         """
         Pretty-print env description.

--- a/robomimic/envs/env_gym.py
+++ b/robomimic/envs/env_gym.py
@@ -25,6 +25,7 @@ class EnvGym(EB.EnvBase):
         render=False, 
         render_offscreen=False, 
         use_image_obs=False, 
+        use_depth_obs=False, 
         postprocess_visual_obs=True, 
         **kwargs,
     ):
@@ -205,7 +206,19 @@ class EnvGym(EB.EnvBase):
         return dict(env_name=self.name, type=self.type, env_kwargs=deepcopy(self._init_kwargs))
 
     @classmethod
-    def create_for_data_processing(cls, env_name, camera_names, camera_height, camera_width, reward_shaping, **kwargs):
+    def create_for_data_processing(
+        cls, 
+        env_name, 
+        camera_names, 
+        camera_height, 
+        camera_width, 
+        reward_shaping, 
+        render=None, 
+        render_offscreen=None, 
+        use_image_obs=None, 
+        use_depth_obs=None, 
+        **kwargs,
+    ):
         """
         Create environment for processing datasets, which includes extracting
         observations, labeling dense / sparse rewards, and annotating dones in

--- a/robomimic/envs/env_ig_momart.py
+++ b/robomimic/envs/env_ig_momart.py
@@ -402,6 +402,13 @@ class EnvGibsonMOMART(EB.EnvBase):
         """Return tuple of exceptions to except when doing rollouts"""
         return (RuntimeError)
 
+    @property
+    def base_env(self):
+        """
+        Grabs base simulation environment.
+        """
+        return self.env
+
     def __repr__(self):
         return self.name + "\n" + json.dumps(self._init_kwargs, sort_keys=True, indent=4) + \
                "\niGibson Config: \n" + json.dumps(self.ig_config, sort_keys=True, indent=4)

--- a/robomimic/envs/env_ig_momart.py
+++ b/robomimic/envs/env_ig_momart.py
@@ -39,6 +39,7 @@ class EnvGibsonMOMART(EB.EnvBase):
             render=False,
             render_offscreen=False,
             use_image_obs=False,
+            use_depth_obs=False,
             image_height=None,
             image_width=None,
             physics_timestep=1./240.,
@@ -59,6 +60,10 @@ class EnvGibsonMOMART(EB.EnvBase):
 
             use_image_obs (bool): if True, environment is expected to render rgb image observations
                 on every env.step call. Set this to False for efficiency reasons, if image
+                observations are not required.
+
+            use_depth_obs (bool): if True, environment is expected to render depth image observations
+                on every env.step call. Set this to False for efficiency reasons, if depth
                 observations are not required.
 
             render_mode (str): How to run simulation rendering. Options are {"pbgui", "iggui", or "headless"}
@@ -331,6 +336,10 @@ class EnvGibsonMOMART(EB.EnvBase):
             camera_height,
             camera_width,
             reward_shaping,
+            render=None, 
+            render_offscreen=None, 
+            use_image_obs=None, 
+            use_depth_obs=None, 
             **kwargs,
     ):
         """
@@ -344,15 +353,18 @@ class EnvGibsonMOMART(EB.EnvBase):
             camera_height (int): camera height for all cameras
             camera_width (int): camera width for all cameras
             reward_shaping (bool): if True, use shaped environment rewards, else use sparse task completion rewards
+            render (bool or None): optionally override rendering behavior
+            render_offscreen (bool or None): optionally override rendering behavior
+            use_image_obs (bool or None): optionally override rendering behavior
         """
         has_camera = (len(camera_names) > 0)
 
         # note that @postprocess_visual_obs is False since this env's images will be written to a dataset
         return cls(
             env_name=env_name,
-            render=False,
-            render_offscreen=has_camera,
-            use_image_obs=has_camera,
+            render=(False if render is None else render), 
+            render_offscreen=(has_camera if render_offscreen is None else render_offscreen), 
+            use_image_obs=(has_camera if use_image_obs is None else use_image_obs), 
             postprocess_visual_obs=False,
             image_height=camera_height,
             image_width=camera_width,

--- a/robomimic/envs/env_robosuite.py
+++ b/robomimic/envs/env_robosuite.py
@@ -490,6 +490,13 @@ class EnvRobosuite(EB.EnvBase):
         """
         return tuple(MUJOCO_EXCEPTIONS)
 
+    @property
+    def base_env(self):
+        """
+        Grabs base simulation environment.
+        """
+        return self.env
+
     def __repr__(self):
         """
         Pretty-print env description.

--- a/robomimic/envs/env_robosuite.py
+++ b/robomimic/envs/env_robosuite.py
@@ -8,6 +8,7 @@ import numpy as np
 from copy import deepcopy
 
 import robosuite
+import robosuite.utils.transform_utils as T
 try:
     # this is needed for ensuring robosuite can find the additional mimicgen environments (see https://mimicgen.github.io)
     import mimicgen_envs
@@ -33,6 +34,7 @@ class EnvRobosuite(EB.EnvBase):
         render=False, 
         render_offscreen=False, 
         use_image_obs=False, 
+        use_depth_obs=False, 
         postprocess_visual_obs=True, 
         **kwargs,
     ):
@@ -70,7 +72,7 @@ class EnvRobosuite(EB.EnvBase):
             ignore_done=True,
             use_object_obs=True,
             use_camera_obs=use_image_obs,
-            camera_depths=False,
+            camera_depths=use_depth_obs,
         )
         kwargs.update(update_kwargs)
 
@@ -86,7 +88,7 @@ class EnvRobosuite(EB.EnvBase):
             # make sure gripper visualization is turned off (we almost always want this for learning)
             kwargs["gripper_visualization"] = False
             del kwargs["camera_depths"]
-            kwargs["camera_depth"] = False # rename kwarg
+            kwargs["camera_depth"] = use_depth_obs # rename kwarg
 
         self._env_name = env_name
         self._init_kwargs = deepcopy(kwargs)
@@ -181,7 +183,10 @@ class EnvRobosuite(EB.EnvBase):
             self.env.viewer.set_camera(cam_id)
             return self.env.render()
         elif mode == "rgb_array":
-            return self.env.sim.render(height=height, width=width, camera_name=camera_name)[::-1]
+            im = self.env.sim.render(height=height, width=width, camera_name=camera_name)[::-1]
+            if self.use_depth_obs:
+                return im[0]
+            return im
         else:
             raise NotImplementedError("mode={} is not implemented".format(mode))
 
@@ -199,6 +204,15 @@ class EnvRobosuite(EB.EnvBase):
         for k in di:
             if (k in ObsUtils.OBS_KEYS_TO_MODALITIES) and ObsUtils.key_is_obs_modality(key=k, obs_modality="rgb"):
                 ret[k] = di[k][::-1]
+                if self.postprocess_visual_obs:
+                    ret[k] = ObsUtils.process_obs(obs=ret[k], obs_key=k)
+            elif (k in ObsUtils.OBS_KEYS_TO_MODALITIES) and ObsUtils.key_is_obs_modality(key=k, obs_modality="depth"):
+                ret[k] = di[k][::-1]
+                if len(ret[k].shape) == 2:
+                    ret[k] = ret[k][..., None] # (H, W, 1)
+                assert len(ret[k].shape) == 3 
+                # scale entries in depth map to correspond to real distance.
+                ret[k] = self.get_real_depth_map(ret[k])
                 if self.postprocess_visual_obs:
                     ret[k] = ObsUtils.process_obs(obs=ret[k], obs_key=k)
 
@@ -221,6 +235,80 @@ class EnvRobosuite(EB.EnvBase):
             ret["eef_quat"] = np.array(di["eef_quat"])
             ret["gripper_qpos"] = np.array(di["gripper_qpos"])
         return ret
+
+    def get_real_depth_map(self, depth_map):
+        """
+        Reproduced from https://github.com/ARISE-Initiative/robosuite/blob/c57e282553a4f42378f2635b9a3cbc4afba270fd/robosuite/utils/camera_utils.py#L106
+        since older versions of robosuite do not have this conversion from normalized depth values returned by MuJoCo
+        to real depth values.
+        """
+        # Make sure that depth values are normalized
+        assert np.all(depth_map >= 0.0) and np.all(depth_map <= 1.0)
+        extent = self.env.sim.model.stat.extent
+        far = self.env.sim.model.vis.map.zfar * extent
+        near = self.env.sim.model.vis.map.znear * extent
+        return near / (1.0 - depth_map * (1.0 - near / far))
+
+    def get_camera_intrinsic_matrix(self, camera_name, camera_height, camera_width):
+        """
+        Obtains camera intrinsic matrix.
+        Args:
+            camera_name (str): name of camera
+            camera_height (int): height of camera images in pixels
+            camera_width (int): width of camera images in pixels
+        Return:
+            K (np.array): 3x3 camera matrix
+        """
+        cam_id = self.env.sim.model.camera_name2id(camera_name)
+        fovy = self.env.sim.model.cam_fovy[cam_id]
+        f = 0.5 * camera_height / np.tan(fovy * np.pi / 360)
+        K = np.array([[f, 0, camera_width / 2], [0, f, camera_height / 2], [0, 0, 1]])
+        return K
+
+    def get_camera_extrinsic_matrix(self, camera_name):
+        """
+        Returns a 4x4 homogenous matrix corresponding to the camera pose in the
+        world frame. MuJoCo has a weird convention for how it sets up the
+        camera body axis, so we also apply a correction so that the x and y
+        axis are along the camera view and the z axis points along the
+        viewpoint.
+        Normal camera convention: https://docs.opencv.org/2.4/modules/calib3d/doc/camera_calibration_and_3d_reconstruction.html
+        Args:
+            camera_name (str): name of camera
+        Return:
+            R (np.array): 4x4 camera extrinsic matrix
+        """
+        cam_id = self.env.sim.model.camera_name2id(camera_name)
+        camera_pos = self.env.sim.data.cam_xpos[cam_id]
+        camera_rot = self.env.sim.data.cam_xmat[cam_id].reshape(3, 3)
+        R = T.make_pose(camera_pos, camera_rot)
+
+        # IMPORTANT! This is a correction so that the camera axis is set up along the viewpoint correctly.
+        camera_axis_correction = np.array(
+            [[1.0, 0.0, 0.0, 0.0], [0.0, -1.0, 0.0, 0.0], [0.0, 0.0, -1.0, 0.0], [0.0, 0.0, 0.0, 1.0]]
+        )
+        R = R @ camera_axis_correction
+        return R
+
+    def get_camera_transform_matrix(self, camera_name, camera_height, camera_width):
+        """
+        Camera transform matrix to project from world coordinates to pixel coordinates.
+        Args:
+            camera_name (str): name of camera
+            camera_height (int): height of camera images in pixels
+            camera_width (int): width of camera images in pixels
+        Return:
+            K (np.array): 4x4 camera matrix to project from world coordinates to pixel coordinates
+        """
+        R = self.get_camera_extrinsic_matrix(camera_name=camera_name)
+        K = self.get_camera_intrinsic_matrix(
+            camera_name=camera_name, camera_height=camera_height, camera_width=camera_width
+        )
+        K_exp = np.eye(4)
+        K_exp[:3, :3] = K
+
+        # Takes a point in world, transforms to camera frame, and then projects onto image plane.
+        return K_exp @ T.pose_inv(R)
 
     def get_state(self):
         """
@@ -318,6 +406,10 @@ class EnvRobosuite(EB.EnvBase):
         camera_height, 
         camera_width, 
         reward_shaping, 
+        render=None, 
+        render_offscreen=None, 
+        use_image_obs=None, 
+        use_depth_obs=None, 
         **kwargs,
     ):
         """
@@ -331,6 +423,10 @@ class EnvRobosuite(EB.EnvBase):
             camera_height (int): camera height for all cameras
             camera_width (int): camera width for all cameras
             reward_shaping (bool): if True, use shaped environment rewards, else use sparse task completion rewards
+            render (bool or None): optionally override rendering behavior
+            render_offscreen (bool or None): optionally override rendering behavior
+            use_image_obs (bool or None): optionally override rendering behavior
+            use_depth_obs (bool or None): optionally override rendering behavior
         """
         is_v1 = (robosuite.__version__.split(".")[0] == "1")
         has_camera = (len(camera_names) > 0)
@@ -355,26 +451,32 @@ class EnvRobosuite(EB.EnvBase):
 
         # also initialize obs utils so it knows which modalities are image modalities
         image_modalities = list(camera_names)
+        depth_modalities = list(camera_names)
         if is_v1:
             image_modalities = ["{}_image".format(cn) for cn in camera_names]
+            depth_modalities = ["{}_depth".format(cn) for cn in camera_names]
         elif has_camera:
-            # v0.3 only had support for one image, and it was named "rgb"
+            # v0.3 only had support for one image, and it was named "image"
             assert len(image_modalities) == 1
-            image_modalities = ["rgb"]
+            image_modalities = ["image"]
+            depth_modalities = ["depth"]
         obs_modality_specs = {
             "obs": {
                 "low_dim": [], # technically unused, so we don't have to specify all of them
                 "rgb": image_modalities,
             }
         }
+        if use_depth_obs:
+            obs_modality_specs["obs"]["depth"] = depth_modalities
         ObsUtils.initialize_obs_utils_with_obs_specs(obs_modality_specs)
 
         # note that @postprocess_visual_obs is False since this env's images will be written to a dataset
         return cls(
             env_name=env_name,
-            render=False, 
-            render_offscreen=has_camera, 
-            use_image_obs=has_camera, 
+            render=(False if render is None else render), 
+            render_offscreen=(has_camera if render_offscreen is None else render_offscreen), 
+            use_image_obs=(has_camera if use_image_obs is None else use_image_obs), 
+            use_depth_obs=use_depth_obs,
             postprocess_visual_obs=False,
             **kwargs,
         )

--- a/robomimic/scripts/dataset_states_to_obs.py
+++ b/robomimic/scripts/dataset_states_to_obs.py
@@ -33,6 +33,10 @@ Example usage:
     python dataset_states_to_obs.py --dataset /path/to/demo.hdf5 --output_name image.hdf5 \
         --done_mode 2 --camera_names agentview robot0_eye_in_hand --camera_height 84 --camera_width 84
 
+    # extract 84x84 image and depth observations
+    python dataset_states_to_obs.py --dataset /path/to/demo.hdf5 --output_name image.hdf5 \
+        --done_mode 2 --camera_names agentview robot0_eye_in_hand --camera_height 84 --camera_width 84 --depth
+
     # (space saving option) extract 84x84 image observations with compression and without 
     # extracting next obs (not needed for pure imitation learning algos)
     python dataset_states_to_obs.py --dataset /path/to/demo.hdf5 --output_name image.hdf5 \
@@ -63,6 +67,9 @@ def extract_trajectory(
     states, 
     actions,
     done_mode,
+    camera_names=None, 
+    camera_height=84, 
+    camera_width=84,
 ):
     """
     Helper function to extract observations, rewards, and dones along a trajectory using
@@ -83,6 +90,17 @@ def extract_trajectory(
     # load the initial state
     env.reset()
     obs = env.reset_to(initial_state)
+
+    # maybe add in intrinsics and extrinsics for all cameras
+    camera_info = None
+    is_robosuite_env = EnvUtils.is_robosuite_env(env=env)
+    if is_robosuite_env:
+        camera_info = get_camera_info(
+            env=env,
+            camera_names=camera_names, 
+            camera_height=camera_height, 
+            camera_width=camera_width,
+        )
 
     traj = dict(
         obs=[], 
@@ -143,10 +161,55 @@ def extract_trajectory(
         else:
             traj[k] = np.array(traj[k])
 
-    return traj
+    return traj, camera_info
+
+
+def get_camera_info(
+    env,
+    camera_names=None, 
+    camera_height=84, 
+    camera_width=84,
+):
+    """
+    Helper function to get camera intrinsics and extrinsics for cameras being used for observations.
+    """
+
+    # TODO: make this function more general than just robosuite environments
+    assert EnvUtils.is_robosuite_env(env=env)
+
+    if camera_names is None:
+        return None
+
+    camera_info = dict()
+    for cam_name in camera_names:
+        K = env.get_camera_intrinsic_matrix(camera_name=cam_name, camera_height=camera_height, camera_width=camera_width)
+        R = env.get_camera_extrinsic_matrix(camera_name=cam_name) # camera pose in world frame
+        if "eye_in_hand" in cam_name:
+            # convert extrinsic matrix to be relative to robot eef control frame
+            assert cam_name.startswith("robot0")
+            eef_site_name = env.base_env.robots[0].controller.eef_name
+            eef_pos = np.array(env.base_env.sim.data.site_xpos[env.base_env.sim.model.site_name2id(eef_site_name)])
+            eef_rot = np.array(env.base_env.sim.data.site_xmat[env.base_env.sim.model.site_name2id(eef_site_name)].reshape([3, 3]))
+            eef_pose = np.zeros((4, 4)) # eef pose in world frame
+            eef_pose[:3, :3] = eef_rot
+            eef_pose[:3, 3] = eef_pos
+            eef_pose[3, 3] = 1.0
+            eef_pose_inv = np.zeros((4, 4))
+            eef_pose_inv[:3, :3] = eef_pose[:3, :3].T
+            eef_pose_inv[:3, 3] = -eef_pose_inv[:3, :3].dot(eef_pose[:3, 3])
+            eef_pose_inv[3, 3] = 1.0
+            R = R.dot(eef_pose_inv) # T_E^W * T_W^C = T_E^C
+        camera_info[cam_name] = dict(
+            intrinsics=K.tolist(),
+            extrinsics=R.tolist(),
+        )
+    return camera_info
 
 
 def dataset_states_to_obs(args):
+    if args.depth:
+        assert len(args.camera_names) > 0, "must specify camera names if using depth"
+
     # create environment to use for data processing
     env_meta = FileUtils.get_env_metadata_from_dataset(dataset_path=args.dataset)
     env = EnvUtils.create_env_for_data_processing(
@@ -155,6 +218,7 @@ def dataset_states_to_obs(args):
         camera_height=args.camera_height, 
         camera_width=args.camera_width, 
         reward_shaping=args.shaped,
+        use_depth_obs=args.depth,
     )
 
     print("==== Using environment with the following metadata ====")
@@ -193,12 +257,15 @@ def dataset_states_to_obs(args):
 
         # extract obs, rewards, dones
         actions = f["data/{}/actions".format(ep)][()]
-        traj = extract_trajectory(
+        traj, camera_info = extract_trajectory(
             env=env, 
             initial_state=initial_state, 
             states=states, 
             actions=actions,
             done_mode=args.done_mode,
+            camera_names=args.camera_names, 
+            camera_height=args.camera_height, 
+            camera_width=args.camera_width,
         )
 
         # maybe copy reward or done signal from source file
@@ -231,6 +298,11 @@ def dataset_states_to_obs(args):
         if is_robosuite_env:
             ep_data_grp.attrs["model_file"] = traj["initial_state_dict"]["model"] # model xml for this episode
         ep_data_grp.attrs["num_samples"] = traj["actions"].shape[0] # number of transitions in this episode
+
+        if camera_info is not None:
+            assert is_robosuite_env
+            ep_data_grp.attrs["camera_info"] = json.dumps(camera_info, indent=4)
+
         total_samples += traj["actions"].shape[0]
 
 
@@ -300,6 +372,13 @@ if __name__ == "__main__":
         type=int,
         default=84,
         help="(optional) width of image observations",
+    )
+
+    # flag for including depth observations per camera
+    parser.add_argument(
+        "--depth", 
+        action='store_true',
+        help="(optional) use depth observations for each camera",
     )
 
     # specifies how the "done" signal is written. If "0", then the "done" signal is 1 wherever 

--- a/robomimic/scripts/dataset_states_to_obs.py
+++ b/robomimic/scripts/dataset_states_to_obs.py
@@ -34,7 +34,7 @@ Example usage:
         --done_mode 2 --camera_names agentview robot0_eye_in_hand --camera_height 84 --camera_width 84
 
     # extract 84x84 image and depth observations
-    python dataset_states_to_obs.py --dataset /path/to/demo.hdf5 --output_name image.hdf5 \
+    python dataset_states_to_obs.py --dataset /path/to/demo.hdf5 --output_name depth.hdf5 \
         --done_mode 2 --camera_names agentview robot0_eye_in_hand --camera_height 84 --camera_width 84 --depth
 
     # (space saving option) extract 84x84 image observations with compression and without 

--- a/robomimic/scripts/playback_dataset.py
+++ b/robomimic/scripts/playback_dataset.py
@@ -49,6 +49,12 @@ Example usage below:
         --use-obs --render_image_names agentview_image \
         --video_path /tmp/obs_trajectory.mp4
 
+    # visualize depth observations along with image observations
+    python playback_dataset.py --dataset /path/to/dataset.hdf5 \
+        --use-obs --render_image_names agentview_image \
+        --render_depth_names agentview_depth \
+        --video_path /tmp/obs_trajectory.mp4
+
     # visualize initial states in the demonstration data
     python playback_dataset.py --dataset /path/to/dataset.hdf5 \
         --first --render_image_names agentview \
@@ -66,6 +72,7 @@ import robomimic
 import robomimic.utils.obs_utils as ObsUtils
 import robomimic.utils.env_utils as EnvUtils
 import robomimic.utils.file_utils as FileUtils
+from robomimic.utils.vis_utils import depth_to_rgb
 from robomimic.envs.env_base import EnvBase, EnvType
 
 
@@ -155,10 +162,11 @@ def playback_trajectory_with_obs(
     video_writer, 
     video_skip=5, 
     image_names=None,
+    depth_names=None,
     first=False,
 ):
     """
-    This function reads all "rgb" observations in the dataset trajectory and
+    This function reads all "rgb" (and possibly "depth") observations in the dataset trajectory and
     writes them into a video.
 
     Args:
@@ -167,10 +175,16 @@ def playback_trajectory_with_obs(
         video_skip (int): determines rate at which environment frames are written to video
         image_names (list): determines which image observations are used for rendering. Pass more than
             one to output a video with multiple image observations concatenated horizontally.
+        depth_names (list): determines which depth observations are used for rendering (if any).
         first (bool): if True, only use the first frame of each episode.
     """
     assert image_names is not None, "error: must specify at least one image observation to use in @image_names"
     video_count = 0
+
+    if depth_names is not None:
+        # compute min and max depth value across trajectory for normalization
+        depth_min = { k : traj_grp["obs/{}".format(k)][:].min() for k in depth_names }
+        depth_max = { k : traj_grp["obs/{}".format(k)][:].max() for k in depth_names }
 
     traj_len = traj_grp["actions"].shape[0]
     for i in range(traj_len):
@@ -178,6 +192,8 @@ def playback_trajectory_with_obs(
             # concatenate image obs together
             im = [traj_grp["obs/{}".format(k)][i] for k in image_names]
             frame = np.concatenate(im, axis=1)
+            depth = [depth_to_rgb(traj_grp["obs/{}".format(k)][i], depth_min=depth_min[k], depth_max=depth_max[k]) for k in depth_names] if depth_names is not None else []
+            frame = np.concatenate(im + depth, axis=1)
             video_writer.append_data(frame)
         video_count += 1
 
@@ -204,6 +220,9 @@ def playback_dataset(args):
     if args.use_obs:
         assert write_video, "playback with observations can only write to video"
         assert not args.use_actions, "playback with observations is offline and does not support action playback"
+
+    if args.render_depth_names is not None:
+        assert args.use_obs, "depth observations can only be visualized from observations currently"
 
     # create environment only if not playing back with observations
     if not args.use_obs:
@@ -253,6 +272,7 @@ def playback_dataset(args):
                 video_writer=video_writer, 
                 video_skip=args.video_skip,
                 image_names=args.render_image_names,
+                depth_names=args.render_depth_names,
                 first=args.first,
             )
             continue
@@ -351,6 +371,15 @@ if __name__ == "__main__":
         default=None,
         help="(optional) camera name(s) / image observation(s) to use for rendering on-screen or to video. Default is"
              "None, which corresponds to a predefined camera for each env type",
+    )
+
+    # depth observations to use for writing to video
+    parser.add_argument(
+        "--render_depth_names",
+        type=str,
+        nargs='+',
+        default=None,
+        help="(optional) depth observation(s) to use for rendering to video"
     )
 
     # Only use the first frame of each episode

--- a/robomimic/scripts/playback_dataset.py
+++ b/robomimic/scripts/playback_dataset.py
@@ -191,7 +191,6 @@ def playback_trajectory_with_obs(
         if video_count % video_skip == 0:
             # concatenate image obs together
             im = [traj_grp["obs/{}".format(k)][i] for k in image_names]
-            frame = np.concatenate(im, axis=1)
             depth = [depth_to_rgb(traj_grp["obs/{}".format(k)][i], depth_min=depth_min[k], depth_max=depth_max[k]) for k in depth_names] if depth_names is not None else []
             frame = np.concatenate(im + depth, axis=1)
             video_writer.append_data(frame)

--- a/robomimic/scripts/train.py
+++ b/robomimic/scripts/train.py
@@ -101,7 +101,8 @@ def train(config, device):
                 env_name=env_name, 
                 render=False, 
                 render_offscreen=config.experiment.render_video,
-                use_image_obs=shape_meta["use_images"], 
+                use_image_obs=shape_meta["use_images"],
+                use_depth_obs=shape_meta["use_depths"],
             )
             env = EnvUtils.wrap_env_from_config(env, config=config) # apply environment warpper, if applicable
             envs[env.name] = env

--- a/robomimic/utils/file_utils.py
+++ b/robomimic/utils/file_utils.py
@@ -82,12 +82,17 @@ def get_demos_for_filter_key(hdf5_path, filter_key):
     return demo_keys
 
 
-def get_env_metadata_from_dataset(dataset_path):
+def get_env_metadata_from_dataset(dataset_path, set_env_specific_obs_processors=True):
     """
     Retrieves env metadata from dataset.
 
     Args:
         dataset_path (str): path to dataset
+
+        set_env_specific_obs_processors (bool): environment might have custom rules for how to process
+            observations - if this flag is true, make sure ObsUtils will use these custom settings. This
+            is a good place to do this operation to make sure it happens before loading data, running a 
+            trained model, etc.
 
     Returns:
         env_meta (dict): environment metadata. Contains 3 keys:
@@ -100,6 +105,9 @@ def get_env_metadata_from_dataset(dataset_path):
     f = h5py.File(dataset_path, "r")
     env_meta = json.loads(f["data"].attrs["env_args"])
     f.close()
+    if set_env_specific_obs_processors:
+        # handle env-specific custom observation processing logic
+        EnvUtils.set_env_specific_obs_processing(env_meta=env_meta)
     return env_meta
 
 
@@ -120,6 +128,7 @@ def get_shape_metadata_from_dataset(dataset_path, all_obs_keys=None, verbose=Fal
             :`'all_shapes'`: dictionary that maps observation key string to shape
             :`'all_obs_keys'`: list of all observation modalities used
             :`'use_images'`: bool, whether or not image modalities are present
+            :`'use_depths'`: bool, whether or not depth modalities are present
     """
 
     shape_meta = {}
@@ -155,6 +164,7 @@ def get_shape_metadata_from_dataset(dataset_path, all_obs_keys=None, verbose=Fal
     shape_meta['all_shapes'] = all_shapes
     shape_meta['all_obs_keys'] = all_obs_keys
     shape_meta['use_images'] = ObsUtils.has_modality("rgb", all_obs_keys)
+    shape_meta['use_depths'] = ObsUtils.has_modality("depth", all_obs_keys)
 
     return shape_meta
 
@@ -438,9 +448,11 @@ def env_from_checkpoint(ckpt_path=None, ckpt_dict=None, env_name=None, render=Fa
     # create env from saved metadata
     env = EnvUtils.create_env_from_metadata(
         env_meta=env_meta, 
+        env_name=env_name, 
         render=render, 
         render_offscreen=render_offscreen,
         use_image_obs=shape_meta["use_images"],
+        use_depth_obs=shape_meta["use_depths"],
     )
     config, _ = config_from_checkpoint(algo_name=ckpt_dict["algo_name"], ckpt_dict=ckpt_dict, verbose=False)
     env = EnvUtils.wrap_env_from_config(env, config=config) # apply environment warpper, if applicable

--- a/robomimic/utils/obs_utils.py
+++ b/robomimic/utils/obs_utils.py
@@ -371,7 +371,7 @@ def process_frame(frame, channel_dim, scale):
     Args:
         frame (np.array or torch.Tensor): frame array
         channel_dim (int): Number of channels to sanity check for
-        scale (float): Value to normalize inputs by
+        scale (float or None): Value to normalize inputs by
 
     Returns:
         processed_frame (np.array or torch.Tensor): processed frame
@@ -379,8 +379,9 @@ def process_frame(frame, channel_dim, scale):
     # Channel size should either be 3 (RGB) or 1 (depth)
     assert (frame.shape[-1] == channel_dim)
     frame = TU.to_float(frame)
-    frame = frame / scale
-    frame = frame.clip(0.0, 1.0)
+    if scale is not None:
+        frame = frame / scale
+        frame = frame.clip(0.0, 1.0)
     frame = batch_image_hwc_to_chw(frame)
 
     return frame
@@ -433,7 +434,7 @@ def unprocess_frame(frame, channel_dim, scale):
     Args:
         frame (np.array or torch.Tensor): frame array
         channel_dim (int): What channel dimension should be (used for sanity check)
-        scale (float): Scaling factor to apply during denormalization
+        scale (float or None): Scaling factor to apply during denormalization
 
     Returns:
         unprocessed_frame (np.array or torch.Tensor): frame passed through
@@ -441,7 +442,8 @@ def unprocess_frame(frame, channel_dim, scale):
     """
     assert frame.shape[-3] == channel_dim # check for channel dimension
     frame = batch_image_chw_to_hwc(frame)
-    frame = frame * scale
+    if scale is not None:
+        frame = scale * frame
     return frame
 
 

--- a/robomimic/utils/vis_utils.py
+++ b/robomimic/utils/vis_utils.py
@@ -4,6 +4,7 @@ These functions can be a useful debugging tool.
 """
 import numpy as np
 import matplotlib.pyplot as plt
+import matplotlib.cm as cm
 
 import robomimic.utils.tensor_utils as TensorUtils
 import robomimic.utils.obs_utils as ObsUtils
@@ -90,3 +91,21 @@ def visualize_image_randomizer(original_image, randomized_image, randomizer_name
 
     # Show the entire grid of subplots
     plt.show()
+
+
+def depth_to_rgb(depth_map, depth_min=None, depth_max=None):
+    """
+    Convert depth map to rgb array by computing normalized depth values in [0, 1].
+    """
+    # normalize depth map into [0, 1]
+    if depth_min is None:
+        depth_min = depth_map.min()
+    if depth_max is None:
+        depth_max = depth_map.max()
+    depth_map = (depth_map - depth_min) / (depth_max - depth_min)
+    # depth_map = np.clip(depth_map / 3., 0., 1.)
+    if len(depth_map.shape) == 3:
+        assert depth_map.shape[-1] == 1
+        depth_map = depth_map[..., 0]
+    assert len(depth_map.shape) == 2 # [H, W]
+    return (255. * cm.hot(depth_map, 3)).astype(np.uint8)[..., :3]


### PR DESCRIPTION
- made some changes to have better support for depth image observations
- support for extracting depth observations from robosuite datasets for use with training, and visualization support as well
- added `base_env` attribute to all environments
- bumped version
- fixed bug with `env_from_checkpoint` ignoring `env_name` arg

Example of extracting depth observations and then visualizing them:
- `python dataset_states_to_obs.py --dataset /tmp/demo.hdf5 --output_name depth.hdf5 --done_mode 2 --camera_names agentview robot0_eye_in_hand --camera_height 84 --camera_width 84 --depth --compress --exclude-next-obs --n 2`
- `python playback_dataset.py --dataset /tmp/depth.hdf5  --use-obs --render_image_names agentview_image robot0_eye_in_hand_image --render_depth_names agentview_depth robot0_eye_in_hand_depth --video_path /tmp/test_depth.mp4`

You can test the above command using the test hdf5 packaged with the repo (e.g. run `examples/simple_train_loop.py`, which will download the test hdf5 at `tests/assets/test_v141.hdf5` and then try the playback command)