### PR TITLE
Add missing "import os"

### DIFF
--- a/robomimic/envs/env_robosuite.py
+++ b/robomimic/envs/env_robosuite.py
@@ -3,6 +3,7 @@ This file contains the robosuite environment wrapper that is used
 to provide a standardized environment API for training policies and interacting
 with metadata present in datasets.
 """
+import os
 import json
 import numpy as np
 from copy import deepcopy


### PR DESCRIPTION
`os` is being used in Line 87, but is never imported, leading to error `NameError: name 'os' is not defined`.