### PR TITLE
Modules registry for supporting custom backbone networks

### DIFF
--- a/robomimic/models/base_nets.py
+++ b/robomimic/models/base_nets.py
@@ -68,21 +68,6 @@ class Module(torch.nn.Module):
     Base class for networks. The only difference from torch.nn.Module is that it
     requires implementing @output_shape.
     """
-    MODULE_REGISTRY = {}
-    def __init_subclass__(cls, **kwargs):
-        """
-        Register all subclasses of Module in the MODULE_REGISTRY 
-        to allow for custom module backbones.
-        """
-        super().__init_subclass__(**kwargs)
-        Module.MODULE_REGISTRY[cls.__name__] = cls
-
-    def get_registered_module(self, name):
-        """
-        Get a registered module by name.
-        """
-        return Module.MODULE_REGISTRY[name]
-
     @abc.abstractmethod
     def output_shape(self, input_shape=None):
         """

--- a/robomimic/models/base_nets.py
+++ b/robomimic/models/base_nets.py
@@ -68,6 +68,21 @@ class Module(torch.nn.Module):
     Base class for networks. The only difference from torch.nn.Module is that it
     requires implementing @output_shape.
     """
+    MODULE_REGISTRY = {}
+    def __init_subclass__(cls, **kwargs):
+        """
+        Register all subclasses of Module in the MODULE_REGISTRY 
+        to allow for custom module backbones.
+        """
+        super().__init_subclass__(**kwargs)
+        Module.MODULE_REGISTRY[cls.__name__] = cls
+
+    def get_registered_module(self, name):
+        """
+        Get a registered module by name.
+        """
+        return Module.MODULE_REGISTRY[name]
+
     @abc.abstractmethod
     def output_shape(self, input_shape=None):
         """
@@ -82,6 +97,7 @@ class Module(torch.nn.Module):
             out_shape ([int]): list of integers corresponding to output shape
         """
         raise NotImplementedError
+
 
 
 class Sequential(torch.nn.Sequential, Module):

--- a/robomimic/models/base_nets.py
+++ b/robomimic/models/base_nets.py
@@ -84,7 +84,6 @@ class Module(torch.nn.Module):
         raise NotImplementedError
 
 
-
 class Sequential(torch.nn.Sequential, Module):
     """
     Compose multiple Modules together (defined above).

--- a/robomimic/models/obs_core.py
+++ b/robomimic/models/obs_core.py
@@ -97,7 +97,10 @@ class VisualCore(EncoderCore, BaseNets.ConvBase):
         backbone_kwargs["input_channel"] = input_shape[0]
 
         # extract only relevant kwargs for this specific backbone
-        backbone_kwargs = extract_class_init_kwargs_from_dict(cls=eval(backbone_class), dic=backbone_kwargs, copy=True)
+        # backbone_kwargs = extract_class_init_kwargs_from_dict(cls=eval(backbone_class), dic=backbone_kwargs, copy=True)
+        backbone_kwargs = extract_class_init_kwargs_from_dict(
+                cls=self.get_registered_module(backbone_class), 
+                dic=backbone_kwargs, copy=True)
 
         # visual backbone
         assert isinstance(backbone_class, str)

--- a/robomimic/models/obs_core.py
+++ b/robomimic/models/obs_core.py
@@ -34,6 +34,8 @@ class EncoderCore(BaseNets.Module):
     """
     Abstract class used to categorize all cores used to encode observations
     """
+    MODULE_REGISTRY = {}
+
     def __init__(self, input_shape):
         self.input_shape = input_shape
         super(EncoderCore, self).__init__()
@@ -97,9 +99,8 @@ class VisualCore(EncoderCore, BaseNets.ConvBase):
         backbone_kwargs["input_channel"] = input_shape[0]
 
         # extract only relevant kwargs for this specific backbone
-        # backbone_kwargs = extract_class_init_kwargs_from_dict(cls=eval(backbone_class), dic=backbone_kwargs, copy=True)
         backbone_kwargs = extract_class_init_kwargs_from_dict(
-                cls=self.get_registered_module(backbone_class), 
+                cls = ObsUtils.OBS_ENCODER_CORES[backbone_class],
                 dic=backbone_kwargs, copy=True)
 
         # visual backbone

--- a/robomimic/models/obs_core.py
+++ b/robomimic/models/obs_core.py
@@ -34,7 +34,6 @@ class EncoderCore(BaseNets.Module):
     """
     Abstract class used to categorize all cores used to encode observations
     """
-    MODULE_REGISTRY = {}
 
     def __init__(self, input_shape):
         self.input_shape = input_shape


### PR DESCRIPTION
Addresses #189 

The implementation consists of adding a registry to the Module class so that all child classes are registered by their name into the registry upon `__init_subclass__`. This allows one to initialized backbones (like in parameters of VisualCore) through the registry rather than using `eval` which only allows models from base_nets.py

Example script coming soon