### PR TITLE
Obs register fix

### DIFF
--- a/robomimic/models/base_nets.py
+++ b/robomimic/models/base_nets.py
@@ -16,6 +16,7 @@ from torchvision import transforms
 from torchvision import models as vision_models
 
 import robomimic.utils.tensor_utils as TensorUtils
+import robomimic.utils.obs_utils as ObsUtils
 
 
 CONV_ACTIVATIONS = {
@@ -462,6 +463,20 @@ class ConvBase(Module):
     """
     def __init__(self):
         super(ConvBase, self).__init__()
+
+    def __init_subclass__(cls, **kwargs):
+        """
+        Hook method to automatically register all valid subclasses so we can keep track of valid observation encoders
+        in a global dict.
+
+        This global dict stores mapping from observation encoder network name to class.
+        We keep track of these registries to enable automated class inference at runtime, allowing
+        users to simply extend our base encoder class and refer to that class in string form
+        in their config, without having to manually register their class internally.
+        This also future-proofs us for any additional encoder classes we would
+        like to add ourselves.
+        """
+        ObsUtils.register_encoder_core(cls)
 
     # dirty hack - re-implement to pass the buck onto subclasses from ABC parent
     def output_shape(self, input_shape):

--- a/robomimic/models/base_nets.py
+++ b/robomimic/models/base_nets.py
@@ -476,7 +476,7 @@ class ConvBase(Module):
         This also future-proofs us for any additional encoder classes we would
         like to add ourselves.
         """
-        ObsUtils.register_encoder_core(cls)
+        ObsUtils.register_encoder_backbone(cls)
 
     # dirty hack - re-implement to pass the buck onto subclasses from ABC parent
     def output_shape(self, input_shape):

--- a/robomimic/models/obs_core.py
+++ b/robomimic/models/obs_core.py
@@ -99,7 +99,7 @@ class VisualCore(EncoderCore, BaseNets.ConvBase):
 
         # extract only relevant kwargs for this specific backbone
         backbone_kwargs = extract_class_init_kwargs_from_dict(
-                cls = ObsUtils.OBS_ENCODER_CORES[backbone_class],
+                cls = ObsUtils.OBS_ENCODER_BACKBONES[backbone_class],
                 dic=backbone_kwargs, copy=True)
 
         # visual backbone

--- a/robomimic/utils/obs_utils.py
+++ b/robomimic/utils/obs_utils.py
@@ -41,8 +41,9 @@ OBS_MODALITY_CLASSES = {}
 # in their config, without having to manually register their class internally.
 # This also future-proofs us for any additional encoder / randomizer classes we would
 # like to add ourselves.
-OBS_ENCODER_CORES = {"None": None}          # Include default None
-OBS_RANDOMIZERS = {"None": None}            # Include default None
+OBS_ENCODER_CORES = {"None": None}          # Per-modality core net as defined in obs_cores.py, e.g., "VisualCore"
+OBS_RANDOMIZERS = {"None": None}            # Obs randomizer defined in obs_cores.py, e.g., "CropRandomizer"
+OBS_ENCODER_BACKBONES = {"None": None}      # Architecture backbones for encoding obervation, e.g., "ResNet18Conv"
 
 
 def register_obs_key(target_class):
@@ -58,6 +59,10 @@ def register_encoder_core(target_class):
 def register_randomizer(target_class):
     assert target_class not in OBS_RANDOMIZERS, f"Already registered obs randomizer {target_class}!"
     OBS_RANDOMIZERS[target_class.__name__] = target_class
+
+def register_encoder_backbone(target_class):
+    assert target_class not in OBS_ENCODER_BACKBONES, f"Already registered obs encoder backbone {target_class}!"
+    OBS_ENCODER_BACKBONES[target_class.__name__] = target_class
 
 
 class ObservationKeyToModalityDict(dict):


### PR DESCRIPTION
#190  introduced a bug into how we create observation backbones in `obs_core.py` by mistakenly referencing `OBS_ENCODER_CORES` defined in `obs_utils.py.` However, we do need a new registry for users to define their own obs encoder backbones such as `ResNet18Conv`. So here is a fix that does that.

* **Changes to `utils/obs_utils.py` and `models/obs_cores.py`**
  * Added `register_encoder_backbone` function in `robomimic/utils/obs_utils.py` to register observation encoder backbones.
  * Introduced `OBS_ENCODER_BACKBONES` dictionary in `robomimic/utils/obs_utils.py` to store mappings of observation encoder network names to classes.
  * Updated the `backbone_kwargs` extraction in `robomimic/models/obs_core.py` to use `OBS_ENCODER_BACKBONES` instead of `OBS_ENCODER_CORES`.
  
* **Class Initialization Updates:**
  * Added `__init_subclass__` method to `ConvBase` class in `robomimic/models/base_nets.py` to automatically register subclasses as valid observation encoders.