### PR TITLE
add robocasa import and ep_meta support

### DIFF
--- a/robomimic/scripts/playback_dataset.py
+++ b/robomimic/scripts/playback_dataset.py
@@ -281,6 +281,7 @@ def playback_dataset(args):
         initial_state = dict(states=states[0])
         if is_robosuite_env:
             initial_state["model"] = f["data/{}".format(ep)].attrs["model_file"]
+            initial_state["ep_meta"] = f["data/{}".format(ep)].attrs.get("ep_meta", None)
 
         # supply actions if using open-loop action playback
         actions = None


### PR DESCRIPTION
* Inside env_robosuite.py, add import for robocasa envs. surround in try-catch just like mimicgen imports
* add support for ep_meta (feature introduced since robosuite v1.5, but this is backwards compatible with older versions too)