### PR TITLE
Fix to resume from last training run

### DIFF
--- a/docs/introduction/getting_started.md
+++ b/docs/introduction/getting_started.md
@@ -36,7 +36,7 @@ Make sure to add the `--debug` flag to your experiments as a sanity check that y
 
 </div>
 
-**Resume functionality**: If your training job fails due to any reason, you can re-launch your job with the additional `--resume` flag to resume training from the last saved epoch. This will resume training from the `last.pth` checkpoint in your output directory. Some points to note:
+**Resume functionality**: If your training job fails due to any reason, you can re-launch your job with the additional `--resume` flag to resume training from the last saved epoch. This will resume training from the `last.pth` checkpoint in your output directory for the most recent training run. Some points to note:
 1. While fine-tuning from a specified checkpoint (in `config.experiment.ckpt_path`) would load model weights from the checkpoint, resume functionality also loads the optimizer state.
 2. `config.experiment.ckpt_path` will be ignored if you are resuming a training job, i.e. `last.pth` will take precedence if `--resume` is passed.
 

--- a/robomimic/utils/train_utils.py
+++ b/robomimic/utils/train_utils.py
@@ -61,8 +61,7 @@ def get_exp_dir(config, auto_remove_exp_dir=False, resume=False):
     if resume:
         assert os.path.exists(base_output_dir), "Resuming training run, but output dir {} does not exist".format(base_output_dir)
         subdir_lst = os.listdir(base_output_dir)
-        assert len(subdir_lst) == 1, "Found more than one subdir {} in output dir {}".format(subdir_lst, base_output_dir)
-        time_str = subdir_lst[0]
+        time_str = sorted(subdir_lst)[-1]  # get the most recent subdirectory
         assert os.path.isdir(os.path.join(base_output_dir, time_str)), "Found item {} that is not a subdirectory in {}".format(time_str, base_output_dir)
     elif os.path.exists(base_output_dir):
         if not auto_remove_exp_dir:


### PR DESCRIPTION
Minor fix to resume training from the most recent run when using the `--resume` flag.