### PR TITLE
fix error when observation_horizon==1 for diffusion policy

### DIFF
--- a/robomimic/envs/wrappers.py
+++ b/robomimic/envs/wrappers.py
@@ -108,7 +108,7 @@ class FrameStackWrapper(EnvWrapper):
                 to stack together. Must be greater than 1 (otherwise this wrapper would
                 be a no-op).
         """
-        assert num_frames > 1, "error: FrameStackWrapper must have num_frames > 1 but got num_frames of {}".format(num_frames)
+        assert num_frames > 0, "error: FrameStackWrapper must have num_frames > 1 but got num_frames of {}".format(num_frames)
 
         super(FrameStackWrapper, self).__init__(env=env)
         self.num_frames = num_frames

--- a/robomimic/utils/env_utils.py
+++ b/robomimic/utils/env_utils.py
@@ -338,7 +338,7 @@ def wrap_env_from_config(env, config):
     Wraps environment using the provided Config object to determine which wrappers
     to use (if any).
     """
-    if ("frame_stack" in config.train) and (config.train.frame_stack > 1):
+    if ("frame_stack" in config.train) and (config.train.frame_stack > 0):
         from robomimic.envs.wrappers import FrameStackWrapper
         env = FrameStackWrapper(env, num_frames=config.train.frame_stack)
 


### PR DESCRIPTION
Currently, when config.horizon.observation_horizon == 1 and config.train.frame_stack == 1, to make To == 1 for Diffusion Policy, it gives shape mismatch error because it doesn't use `FrameStackWrapper` which stacks observation along the temporal dimension. This PR fixes that by making sure to use FrameStackWrapper as long as config.train.frame_stack >0 to make the shapes consistent. 