### PR TITLE
fix rot_conversion mechanism for action_config

### DIFF
--- a/robomimic/algo/algo.py
+++ b/robomimic/algo/algo.py
@@ -577,8 +577,8 @@ class RolloutPolicy(object):
             ac_dict = ObsUtils.unnormalize_dict(ac_dict, normalization_stats=self.action_normalization_stats)
             action_config = self.policy.global_config.train.action_config
             for key, value in ac_dict.items():
-                this_format = action_config[key].get("format", None)
-                if this_format == "rot_6d":
+                rot_conversion = action_config[key].get("rot_conversion", None)
+                if rot_conversion == "axis_angle_to_6d":
                     rot_6d = torch.from_numpy(value).unsqueeze(0)
                     conversion_format = action_config[key].get("convert_at_runtime", "rot_axis_angle")
                     if conversion_format == "rot_axis_angle":

--- a/robomimic/utils/dataset.py
+++ b/robomimic/utils/dataset.py
@@ -911,5 +911,12 @@ def action_stats_to_normalization_stats(action_stats, action_config):
         else:
             raise NotImplementedError(
                 'action_config.actions.normalization: "{}" is not supported'.format(norm_method))
-    
+
+    if (
+        action_key in action_config
+        and isinstance(action_config[action_key], dict)
+        and action_config[action_key].get("rot_conversion") is not None
+    ):
+        action_normalization_stats[action_key]["rot_conversion"] = action_config[action_key]["rot_conversion"]
+        
     return action_normalization_stats

--- a/robomimic/utils/train_utils.py
+++ b/robomimic/utils/train_utils.py
@@ -630,8 +630,8 @@ def save_model(model, config, env_meta, shape_meta, ckpt_path, variable_state=No
     if action_normalization_stats is not None:
         action_normalization_stats = deepcopy(action_normalization_stats)
         for k in action_normalization_stats:
-            if 'rot_conversion' in action_normalization_stats[k]:
-                action_normalization_stats[k].pop('rot_conversion')
+            if "rot_conversion" in action_normalization_stats[k]:
+                action_normalization_stats[k].pop("rot_conversion")
         params["action_normalization_stats"] = TensorUtils.to_list(action_normalization_stats)
     torch.save(params, ckpt_path)
     print("save checkpoint to {}".format(ckpt_path))

--- a/robomimic/utils/train_utils.py
+++ b/robomimic/utils/train_utils.py
@@ -629,6 +629,9 @@ def save_model(model, config, env_meta, shape_meta, ckpt_path, variable_state=No
         params["obs_normalization_stats"] = TensorUtils.to_list(obs_normalization_stats)
     if action_normalization_stats is not None:
         action_normalization_stats = deepcopy(action_normalization_stats)
+        for k in action_normalization_stats:
+            if 'rot_conversion' in action_normalization_stats[k]:
+                action_normalization_stats[k].pop('rot_conversion')
         params["action_normalization_stats"] = TensorUtils.to_list(action_normalization_stats)
     torch.save(params, ckpt_path)
     print("save checkpoint to {}".format(ckpt_path))


### PR DESCRIPTION
Currently, it doesn't support having rot_conversion for action_config. The rot_conversion argument seems to have become incompatible due to previous changes in the code base. 

For example, when the config has the following action_config:

>         "action_config": {
>             "action_dict/abs_pos": {
>                 "normalization": "min_max",  
>                 "rot_conversion": null 
>             },
>             "action_dict/abs_rot_6d": {
>                 "normalization": "min_max",  
>                 "rot_conversion": "axis_angle_to_6d"
>             },
>             "action_dict/gripper": {
>                 "normalization": "min_max",  
>                 "rot_conversion": null 
>             }


it doesn't properly reshape "action_dict/abs_rot_6d" back to the original rotation action representation. This PR fixes this issue by adding the mechanism for converting the rotation action with rot_conversion config. 