### PR TITLE
Enable camera obs for either RGB or depth

### DIFF
--- a/robomimic/scripts/train.py
+++ b/robomimic/scripts/train.py
@@ -139,7 +139,7 @@ def train(config, device, resume=False):
                     env_name=env_name,
                     render=False,
                     render_offscreen=config.experiment.render_video,
-                    use_image_obs=shape_meta["use_images"],
+                    use_image_obs=shape_meta["use_images"] or shape_meta["use_depths"],
                 )
                 env = EnvUtils.create_env_from_metadata(**env_kwargs)
                 # handle environment wrappers


### PR DESCRIPTION
Fixes a minor bug in `train.py` where we enable camera obs only for RGB observations. So, if just depths were requested (by setting `camera_depths=True`), and not RGB, robosuite won’t return depths either. This PR fixes this issue.