### PR TITLE
Lazy-load CLIP language encoder

### DIFF
--- a/robomimic/utils/lang_utils.py
+++ b/robomimic/utils/lang_utils.py
@@ -1,31 +1,45 @@
 import os
-from transformers import AutoModel, pipeline, AutoTokenizer, CLIPTextModelWithProjection
+from functools import lru_cache
 
-os.environ["TOKENIZERS_PARALLELISM"] = "true" # needed to suppress warning about potential deadlock
-tokenizer = "openai/clip-vit-large-patch14" #"openai/clip-vit-base-patch32"
-lang_emb_model = CLIPTextModelWithProjection.from_pretrained(
-    tokenizer,
-    cache_dir=os.path.expanduser(os.path.join(os.environ.get("HF_HOME", "~/tmp"), "clip"))
-).eval()
-tz = AutoTokenizer.from_pretrained(tokenizer, TOKENIZERS_PARALLELISM=True)
+from transformers import AutoTokenizer, CLIPTextModelWithProjection
+
+os.environ["TOKENIZERS_PARALLELISM"] = (
+    "true"  # needed to suppress warning about potential deadlock
+)
+tokenizer = "openai/clip-vit-large-patch14"  # "openai/clip-vit-base-patch32"
 
 LANG_EMB_OBS_KEY = "lang_emb"
+
+
+@lru_cache(maxsize=1)
+def _get_language_encoder():
+    lang_emb_model = CLIPTextModelWithProjection.from_pretrained(
+        tokenizer,
+        cache_dir=os.path.expanduser(
+            os.path.join(os.environ.get("HF_HOME", "~/tmp"), "clip")
+        ),
+    ).eval()
+    tz = AutoTokenizer.from_pretrained(tokenizer, TOKENIZERS_PARALLELISM=True)
+    return lang_emb_model, tz
+
 
 def get_lang_emb(lang):
     if lang is None:
         return None
-    
+
+    lang_emb_model, tz = _get_language_encoder()
     tokens = tz(
-        text=lang,                   # the sentence to be encoded
-        add_special_tokens=True,             # Add [CLS] and [SEP]
+        text=lang,  # the sentence to be encoded
+        add_special_tokens=True,  # Add [CLS] and [SEP]
         max_length=25,  # maximum length of a sentence
         padding="max_length",
-        return_attention_mask=True,        # Generate the attention mask
-        return_tensors="pt",               # ask the function to return PyTorch tensors
+        return_attention_mask=True,  # Generate the attention mask
+        return_tensors="pt",  # ask the function to return PyTorch tensors
     )
-    lang_emb = lang_emb_model(**tokens)['text_embeds'].detach()[0]
+    lang_emb = lang_emb_model(**tokens)["text_embeds"].detach()[0]
 
     return lang_emb
 
+
 def get_lang_emb_shape():
-    return list(get_lang_emb('dummy').shape)
+    return list(get_lang_emb("dummy").shape)

--- a/tests/test_lang_utils.py
+++ b/tests/test_lang_utils.py
@@ -1,0 +1,50 @@
+import importlib
+from types import ModuleType
+import sys
+
+import torch
+
+
+def test_language_encoder_is_loaded_only_when_requested(monkeypatch):
+    calls = []
+
+    class FakeModel:
+        @classmethod
+        def from_pretrained(cls, *_args, **_kwargs):
+            calls.append("model")
+            return cls()
+
+        def eval(self):
+            return self
+
+        def __call__(self, **_kwargs):
+            return {"text_embeds": torch.zeros((1, 8))}
+
+    class FakeTokenizer:
+        @classmethod
+        def from_pretrained(cls, *_args, **_kwargs):
+            calls.append("tokenizer")
+            return cls()
+
+        def __call__(self, **_kwargs):
+            return {}
+
+    transformers = ModuleType("transformers")
+    transformers.AutoModel = object
+    transformers.pipeline = object
+    transformers.AutoTokenizer = FakeTokenizer
+    transformers.CLIPTextModelWithProjection = FakeModel
+    monkeypatch.setitem(sys.modules, "transformers", transformers)
+    for module_name in tuple(sys.modules):
+        if module_name == "robomimic" or module_name.startswith("robomimic."):
+            monkeypatch.delitem(sys.modules, module_name)
+
+    lang_utils = importlib.import_module("robomimic.utils.lang_utils")
+
+    assert calls == []
+    assert lang_utils.get_lang_emb(None) is None
+    assert calls == []
+    assert tuple(lang_utils.get_lang_emb("pick up the cube").shape) == (8,)
+    assert calls == ["model", "tokenizer"]
+    lang_utils.get_lang_emb("place the cube")
+    assert calls == ["model", "tokenizer"]


### PR DESCRIPTION
## Summary

- defer CLIP model and tokenizer construction until a non-null language embedding is requested
- cache the initialized encoder for later calls
- remove unused transformer imports

This keeps non-language dataset imports and training offline and avoids an unnecessary 1.7 GB download.

Closes #300.

## Test

`pytest -q tests/test_lang_utils.py`