### PR TITLE
Lazy CLIP download

### DIFF
--- a/robomimic/scripts/train.py
+++ b/robomimic/scripts/train.py
@@ -37,6 +37,7 @@ import robomimic.utils.torch_utils as TorchUtils
 import robomimic.utils.obs_utils as ObsUtils
 import robomimic.utils.env_utils as EnvUtils
 import robomimic.utils.file_utils as FileUtils
+import robomimic.utils.lang_utils as LangUtils
 from robomimic.config import config_factory
 from robomimic.algo import algo_factory, RolloutPolicy
 from robomimic.utils.log_utils import PrintLogger, DataLogger, flush_warnings
@@ -87,8 +88,13 @@ def train(config, device, resume=False):
         print("\n============= Loaded Environment Metadata =============")
         env_meta = FileUtils.get_env_metadata_from_dataset(dataset_path=dataset_path)
 
-        # populate language instruction for env in env_meta
-        env_meta["lang"] = dataset_cfg.get("lang", "dummy")
+        # Populate language instruction for env in env_meta, but only if the policy is
+        # language conditioned - otherwise leave it unset so that the env does not need
+        # to compute (and thus load the model for) language embeddings
+        if LangUtils.LANG_EMB_OBS_KEY in config.all_obs_keys:
+            env_meta["lang"] = dataset_cfg.get("lang", "dummy")
+        else:
+            env_meta["lang"] = None
 
         # update env meta if applicable
         from robomimic.utils.python_utils import deep_update

--- a/robomimic/utils/lang_utils.py
+++ b/robomimic/utils/lang_utils.py
@@ -1,20 +1,37 @@
 import os
-from transformers import AutoModel, pipeline, AutoTokenizer, CLIPTextModelWithProjection
 
 os.environ["TOKENIZERS_PARALLELISM"] = "true" # needed to suppress warning about potential deadlock
 tokenizer = "openai/clip-vit-large-patch14" #"openai/clip-vit-base-patch32"
-lang_emb_model = CLIPTextModelWithProjection.from_pretrained(
-    tokenizer,
-    cache_dir=os.path.expanduser(os.path.join(os.environ.get("HF_HOME", "~/tmp"), "clip"))
-).eval()
-tz = AutoTokenizer.from_pretrained(tokenizer, TOKENIZERS_PARALLELISM=True)
 
 LANG_EMB_OBS_KEY = "lang_emb"
+
+# lazily initialized on first call to @get_lang_emb, so that runs without language
+# conditioning never pay for downloading / loading the CLIP model
+lang_emb_model = None
+tz = None
+
+def _load_lang_emb_model():
+    """
+    Load the CLIP text model and tokenizer on first use, and cache them for subsequent calls.
+    """
+    global lang_emb_model, tz
+
+    if lang_emb_model is None:
+        from transformers import AutoTokenizer, CLIPTextModelWithProjection
+        lang_emb_model = CLIPTextModelWithProjection.from_pretrained(
+            tokenizer,
+            cache_dir=os.path.expanduser(os.path.join(os.environ.get("HF_HOME", "~/tmp"), "clip"))
+        ).eval()
+        tz = AutoTokenizer.from_pretrained(tokenizer, TOKENIZERS_PARALLELISM=True)
+
+    return lang_emb_model, tz
 
 def get_lang_emb(lang):
     if lang is None:
         return None
-    
+
+    lang_emb_model, tz = _load_lang_emb_model()
+
     tokens = tz(
         text=lang,                   # the sentence to be encoded
         add_special_tokens=True,             # Add [CLS] and [SEP]

--- a/robomimic/utils/train_utils.py
+++ b/robomimic/utils/train_utils.py
@@ -163,7 +163,9 @@ def dataset_factory(config, obs_keys, filter_by_attribute=None, dataset_path=Non
     # NOTE: currently supporting fixed language embedding per dataset
     ## that is fetched from dataset config and not from file
     if LangUtils.LANG_EMB_OBS_KEY in obs_keys:
-        obs_keys.remove(LangUtils.LANG_EMB_OBS_KEY)
+        ## NOTE: copy rather than mutate, since the caller reuses the same obs_keys list for
+        ## both the train and validation datasets (and in shape_meta afterwards)
+        obs_keys = [k for k in obs_keys if k != LangUtils.LANG_EMB_OBS_KEY]
         ds_langs = [ds_cfg.get("lang", "dummy") for ds_cfg in config.train.data]
     else:
         ds_langs = [None for _ in config.train.data]


### PR DESCRIPTION
**Only download CLIP when the policy is language-conditioned**

**Old behavior:** `robomimic/utils/lang_utils.py` downloaded and instantiated the CLIP text encoder (openai/clip-vit-large-patch14, ~1.6 GB) at import time since `lang_utils` is imported by `train_utils`, `file_utils`, and `obs_nets`, even when there is no language conditioning at all. 

**List of changes:**
1. Lazy-load the CLIP model (`utils/lang_utils.py`)
2. Don't hand the env a language instruction it doesn't need (`scripts/train.py`)
3. Bugfix: don't mutate the caller's obs_keys list (`utils/train_utils.py`)

